### PR TITLE
feat(landing): 랜딩 페이지 스캐폴드 및 글로벌 토큰 구성

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link
@@ -8,7 +8,25 @@
       href="%BASE_URL%cju-likelion-symbol.svg"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>temp-vite</title>
+    <meta
+      name="description"
+      content="청주대학교 멋쟁이사자처럼 14기 모집 랜딩 페이지. 트랙 소개, 운영진, 커리큘럼, 연간 일정, 지원 링크를 제공합니다."
+    />
+    <script>
+      (function () {
+        try {
+          const stored = localStorage.getItem("theme");
+          const prefersDark =
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches;
+          const isDark = stored ? stored === "dark" : prefersDark;
+          document.documentElement.classList.toggle("dark", isDark);
+        } catch {
+          // ignore
+        }
+      })();
+    </script>
+    <title>청주대학교 멋쟁이사자처럼 14기 | LIKELION CJU</title>
   </head>
 
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,7 @@
-import { useState } from "react";
-import reactLogo from "./assets/react.svg";
-import viteLogo from "./assets/vite.svg";
-import "./App.css";
+import { LandingPage } from "@/pages/LandingPage";
 
 function App() {
-  const [count, setCount] = useState(0);
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  );
+  return <LandingPage />;
 }
 
 export default App;

--- a/src/components/motion/Reveal.tsx
+++ b/src/components/motion/Reveal.tsx
@@ -1,0 +1,26 @@
+import { useRef } from "react";
+import type { ReactNode } from "react";
+
+import { useInView } from "@/hooks/useInView";
+
+type RevealProps = {
+  children: ReactNode;
+  className?: string;
+  once?: boolean;
+};
+
+export function Reveal({ children, className, once = true }: RevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once });
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      data-reveal
+      data-inview={inView ? "true" : "false"}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -1,0 +1,9 @@
+export function AboutSection() {
+  return (
+    <section id="about" className="scroll-mt-16 px-5 py-24">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="text-3xl font-black md:text-5xl">About</h2>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/ApplySection.tsx
+++ b/src/components/sections/ApplySection.tsx
@@ -1,0 +1,18 @@
+export function ApplySection() {
+  return (
+    <section id="apply" className="scroll-mt-16 px-5 py-24">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="mb-6 text-3xl font-black md:text-5xl">Apply</h2>
+        <a
+          data-testid="apply-cta"
+          href="https://forms.gle/7M8Dfxv63tGuSEJ56"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex rounded-full bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+        >
+          14기 지원하러 가기
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/CurriculumSection.tsx
+++ b/src/components/sections/CurriculumSection.tsx
@@ -1,0 +1,9 @@
+export function CurriculumSection() {
+  return (
+    <section id="curriculum" className="scroll-mt-16 px-5 py-24">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="text-3xl font-black md:text-5xl">Curriculum</h2>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/IntroSection.tsx
+++ b/src/components/sections/IntroSection.tsx
@@ -1,0 +1,25 @@
+import { Reveal } from "@/components/motion/Reveal";
+
+export function IntroSection() {
+  return (
+    <section
+      id="intro"
+      className="min-h-screen scroll-mt-16 bg-background px-5 pb-20 pt-28"
+    >
+      <div className="mx-auto max-w-6xl">
+        <Reveal>
+          <p className="mb-4 text-xs tracking-[0.25em] text-primary uppercase">
+            LIKELION 14TH GENERATION @ CJU
+          </p>
+          <h1 className="text-4xl font-black tracking-tight text-foreground md:text-7xl">
+            BUILD YOUR
+            <br />
+            <span className="bg-gradient-to-r from-[var(--brand-500)] to-[var(--brand-400)] bg-clip-text text-transparent">
+              OWN UNIVERSE
+            </span>
+          </h1>
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/RoadmapSection.tsx
+++ b/src/components/sections/RoadmapSection.tsx
@@ -1,0 +1,9 @@
+export function RoadmapSection() {
+  return (
+    <section id="roadmap" className="scroll-mt-16 bg-card px-5 py-24">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="text-3xl font-black md:text-5xl">Roadmap</h2>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/TeamSection.tsx
+++ b/src/components/sections/TeamSection.tsx
@@ -1,0 +1,9 @@
+export function TeamSection() {
+  return (
+    <section id="team" className="scroll-mt-16 bg-card px-5 py-24">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="text-3xl font-black md:text-5xl">Team</h2>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/VisionSection.tsx
+++ b/src/components/sections/VisionSection.tsx
@@ -1,0 +1,9 @@
+export function VisionSection() {
+  return (
+    <section id="vision" className="scroll-mt-16 bg-card px-5 py-24">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="text-3xl font-black md:text-5xl">Our Vision</h2>
+      </div>
+    </section>
+  );
+}

--- a/src/components/site/DotNav.tsx
+++ b/src/components/site/DotNav.tsx
@@ -1,0 +1,28 @@
+import { navigationItems } from "@/content/landing";
+
+type DotNavProps = {
+  activeId: string;
+};
+
+export function DotNav({ activeId }: DotNavProps) {
+  return (
+    <nav className="fixed right-6 top-1/2 z-40 hidden -translate-y-1/2 lg:block">
+      <ul className="flex flex-col gap-3">
+        {navigationItems.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                aria-current={isActive ? "true" : undefined}
+                className="block h-2 w-2 rounded-full bg-muted-foreground"
+              >
+                <span className="sr-only">{item.label}</span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -1,9 +1,11 @@
 export function SiteFooter() {
+  const currentYear = new Date().getFullYear();
+
   return (
     <footer className="border-t border-border py-10">
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-5 text-sm text-muted-foreground md:flex-row">
         <p className="font-semibold text-foreground">LIKELION CJU</p>
-        <p>© 2026 LIKELION CJU. All rights reserved.</p>
+        <p>© {currentYear} LIKELION CJU. All rights reserved.</p>
       </div>
     </footer>
   );

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -1,0 +1,10 @@
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-border py-10">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-5 text-sm text-muted-foreground md:flex-row">
+        <p className="font-semibold text-foreground">LIKELION CJU</p>
+        <p>© 2026 LIKELION CJU. All rights reserved.</p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -1,0 +1,50 @@
+import { navigationItems } from "@/content/landing";
+
+type SiteHeaderProps = {
+  activeId: string;
+};
+
+export function SiteHeader({ activeId }: SiteHeaderProps) {
+  return (
+    <header
+      data-testid="site-header"
+      className="fixed inset-x-0 top-0 z-50 border-b border-transparent bg-background/70 backdrop-blur"
+    >
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-5">
+        <a href="#intro" className="font-black tracking-wide">
+          LIKELION <span className="text-primary">CJU</span>
+        </a>
+
+        <nav className="hidden items-center gap-6 md:flex" aria-label="Primary">
+          {navigationItems.map((item) => {
+            const isActive = item.id === activeId;
+            return (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                aria-current={isActive ? "true" : undefined}
+                className="text-xs tracking-[0.15em] uppercase"
+              >
+                {item.label}
+              </a>
+            );
+          })}
+        </nav>
+
+        <button
+          type="button"
+          data-testid="mobile-nav-toggle"
+          className="inline-flex h-9 items-center rounded-md border border-border px-3 text-xs md:hidden"
+          aria-label="Toggle navigation"
+        >
+          Menu
+        </button>
+      </div>
+
+      <div
+        data-testid="mobile-nav-panel"
+        className="hidden border-t border-border px-5 py-3 md:hidden"
+      />
+    </header>
+  );
+}

--- a/src/content/landing.ts
+++ b/src/content/landing.ts
@@ -1,0 +1,25 @@
+export type SectionId =
+  | "intro"
+  | "vision"
+  | "about"
+  | "team"
+  | "curriculum"
+  | "roadmap"
+  | "apply";
+
+export type NavigationItem = {
+  id: SectionId;
+  label: string;
+};
+
+export const navigationItems: NavigationItem[] = [
+  { id: "intro", label: "Home" },
+  { id: "vision", label: "Vision" },
+  { id: "about", label: "About" },
+  { id: "team", label: "Team" },
+  { id: "curriculum", label: "Class" },
+  { id: "roadmap", label: "Schedule" },
+  { id: "apply", label: "Apply" },
+];
+
+export const sectionOrder: SectionId[] = navigationItems.map((item) => item.id);

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import type { RefObject } from "react";
+
+type UseInViewOptions = {
+  rootMargin?: string;
+  threshold?: number | number[];
+  once?: boolean;
+};
+
+export function useInView<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  options: UseInViewOptions = {},
+) {
+  const { rootMargin = "-10% 0px -20% 0px", threshold = 0.15, once = true } =
+    options;
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const target = ref.current;
+    if (!target) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          if (once) {
+            observer.unobserve(target);
+          }
+        } else if (!once) {
+          setInView(false);
+        }
+      },
+      { rootMargin, threshold },
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [once, ref, rootMargin, threshold]);
+
+  return inView;
+}

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    onChange();
+    mediaQuery.addEventListener("change", onChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -1,0 +1,72 @@
+import { useEffect, useMemo, useState } from "react";
+
+type ScrollSpyOptions = {
+  rootMargin?: string;
+  threshold?: number[];
+};
+
+export function useScrollSpy(
+  sectionIds: string[],
+  options: ScrollSpyOptions = {},
+) {
+  const { rootMargin = "-64px 0px -70% 0px", threshold = [0, 0.1, 0.25, 0.5] } =
+    options;
+  const [activeId, setActiveId] = useState<string>(sectionIds[0] ?? "");
+
+  const orderMap = useMemo(() => {
+    return new Map(sectionIds.map((id, index) => [id, index]));
+  }, [sectionIds]);
+
+  useEffect(() => {
+    const ratios = new Map<string, number>();
+    const targets = sectionIds
+      .map((id) => document.getElementById(id))
+      .filter((element): element is HTMLElement => element !== null);
+
+    if (targets.length === 0) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          ratios.set(entry.target.id, entry.intersectionRatio);
+        }
+
+        const nextId = sectionIds.reduce<string>((best, id) => {
+          const bestRatio = ratios.get(best) ?? 0;
+          const currentRatio = ratios.get(id) ?? 0;
+
+          if (currentRatio > bestRatio) {
+            return id;
+          }
+
+          if (currentRatio === bestRatio) {
+            const bestOrder = orderMap.get(best) ?? Number.MAX_SAFE_INTEGER;
+            const currentOrder = orderMap.get(id) ?? Number.MAX_SAFE_INTEGER;
+            if (currentOrder < bestOrder) {
+              return id;
+            }
+          }
+
+          return best;
+        }, sectionIds[0] ?? "");
+
+        if (nextId) {
+          setActiveId(nextId);
+        }
+      },
+      { rootMargin, threshold },
+    );
+
+    for (const target of targets) {
+      observer.observe(target);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [orderMap, rootMargin, sectionIds, threshold]);
+
+  return activeId;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;900&family=Noto+Sans+KR:wght@300;400;500;700&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
@@ -12,6 +13,7 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -47,71 +49,93 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+
+  --background: #ffffff;
+  --foreground: #0f172a;
+  --card: #ffffff;
+  --card-foreground: #0f172a;
+  --popover: #ffffff;
+  --popover-foreground: #0f172a;
+  --primary: #ff4d00;
+  --primary-foreground: #ffffff;
+  --secondary: #f4f4f5;
+  --secondary-foreground: #18181b;
+  --muted: #f4f4f5;
+  --muted-foreground: #6b7280;
+  --accent: rgba(255, 77, 0, 0.12);
+  --accent-foreground: #0f172a;
+  --destructive: #d4183d;
+  --border: #e5e7eb;
+  --input: #e5e7eb;
+  --ring: #ff4d00;
+
+  --chart-1: #fb923c;
+  --chart-2: #22d3ee;
+  --chart-3: #818cf8;
+  --chart-4: #f59e0b;
+  --chart-5: #ef4444;
+
+  --sidebar: #ffffff;
+  --sidebar-foreground: #0f172a;
+  --sidebar-primary: #ff4d00;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f4f4f5;
+  --sidebar-accent-foreground: #18181b;
+  --sidebar-border: #e5e7eb;
+  --sidebar-ring: #ff4d00;
+
+  --brand-500: #ff4d00;
+  --brand-400: #ff8c00;
+  --brand-600: #ff6a2b;
+  --canvas-1: #050505;
+  --canvas-2: #0a0a0a;
 }
 
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+html.dark {
+  --background: #050505;
+  --foreground: #ffffff;
+  --card: #0a0a0a;
+  --card-foreground: #ffffff;
+  --popover: #0a0a0a;
+  --popover-foreground: #ffffff;
+  --primary: #ff4d00;
+  --primary-foreground: #ffffff;
+  --secondary: rgba(255, 255, 255, 0.04);
+  --secondary-foreground: #ffffff;
+  --muted: rgba(255, 255, 255, 0.06);
+  --muted-foreground: #9ca3af;
+  --accent: rgba(255, 77, 0, 0.1);
+  --accent-foreground: #ffffff;
+  --destructive: #fb7185;
+  --border: rgba(255, 255, 255, 0.06);
+  --input: rgba(255, 255, 255, 0.1);
+  --ring: #ff4d00;
+
+  --chart-1: #fb923c;
+  --chart-2: #22d3ee;
+  --chart-3: #818cf8;
+  --chart-4: #f59e0b;
+  --chart-5: #ef4444;
+
+  --sidebar: #0a0a0a;
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #ff4d00;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(255, 255, 255, 0.04);
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: rgba(255, 255, 255, 0.06);
+  --sidebar-ring: #ff4d00;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 64px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
 }
 
 @layer base {
@@ -121,5 +145,57 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: "Noto Sans KR", sans-serif;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  .nav-label {
+    font-family: "Montserrat", sans-serif;
+  }
+}
+
+::selection {
+  background: var(--brand-500);
+  color: #ffffff;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--background);
+}
+
+::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--foreground) 28%, transparent);
+  border-radius: 999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--brand-500);
+}
+
+[data-reveal] {
+  opacity: 0;
+  transform: translate3d(0, 16px, 0);
+  transition:
+    opacity 600ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 600ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-reveal][data-inview="true"] {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] {
+    opacity: 1;
+    transform: none;
+    transition: none;
   }
 }

--- a/src/lib/scroll.ts
+++ b/src/lib/scroll.ts
@@ -1,0 +1,19 @@
+type ScrollToIdOptions = {
+  behavior?: ScrollBehavior;
+  updateHash?: boolean;
+};
+
+export function scrollToId(id: string, options: ScrollToIdOptions = {}) {
+  const { behavior = "smooth", updateHash = true } = options;
+  const element = document.getElementById(id);
+
+  if (!element) {
+    return;
+  }
+
+  element.scrollIntoView({ behavior, block: "start" });
+
+  if (updateHash) {
+    history.replaceState(null, "", `#${id}`);
+  }
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,35 @@
+import { AboutSection } from "@/components/sections/AboutSection";
+import { ApplySection } from "@/components/sections/ApplySection";
+import { CurriculumSection } from "@/components/sections/CurriculumSection";
+import { IntroSection } from "@/components/sections/IntroSection";
+import { RoadmapSection } from "@/components/sections/RoadmapSection";
+import { TeamSection } from "@/components/sections/TeamSection";
+import { VisionSection } from "@/components/sections/VisionSection";
+import { DotNav } from "@/components/site/DotNav";
+import { SiteFooter } from "@/components/site/SiteFooter";
+import { SiteHeader } from "@/components/site/SiteHeader";
+import { sectionOrder } from "@/content/landing";
+import { useScrollSpy } from "@/hooks/useScrollSpy";
+
+export function LandingPage() {
+  const activeId = useScrollSpy(sectionOrder);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <SiteHeader activeId={activeId} />
+      <DotNav activeId={activeId} />
+
+      <main>
+        <IntroSection />
+        <VisionSection />
+        <AboutSection />
+        <TeamSection />
+        <CurriculumSection />
+        <RoadmapSection />
+        <ApplySection />
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 사항
- Vite 기본 화면을 랜딩 페이지 스캐폴드(`LandingPage`)로 교체하고, Stage 1 섹션/사이트 컴포넌트 플레이스홀더를 추가했습니다.
- `index.html`에 글로벌 메타데이터와 테마 부트스트랩 스크립트를 추가했습니다.
- `src/index.css`에서 라이트/다크 디자인 토큰을 분리하고, 글로벌 타이포그래피/스크롤 기본값을 적용했습니다.

## 목적
- 이후 단계에서 상호작용 구현, 전체 섹션 콘텐츠 완성, E2E 테스트 추가에 집중할 수 있도록 Stage 1 기반을 먼저 구축합니다.

## 검증 방법
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run build`