### PR TITLE
feat(landing): add scrollspy + header/nav interactions

### DIFF
--- a/src/components/site/DotNav.tsx
+++ b/src/components/site/DotNav.tsx
@@ -13,7 +13,7 @@ export function DotNav({ activeId, onNavigate }: DotNavProps) {
         {navigationItems.map((item) => {
           const isActive = item.id === activeId;
           return (
-            <li key={item.id}>
+            <li key={item.id} className="flex h-4 w-4 items-center justify-center">
               <a
                 href={`#${item.id}`}
                 aria-current={isActive ? "true" : undefined}
@@ -22,12 +22,18 @@ export function DotNav({ activeId, onNavigate }: DotNavProps) {
                   onNavigate(item.id);
                 }}
                 className={cn(
-                  "block rounded-full transition-all duration-200",
-                  isActive
-                    ? "h-4 w-4 bg-primary"
-                    : "h-2 w-2 bg-muted-foreground hover:bg-foreground/70",
+                  "group flex h-4 w-4 items-center justify-center rounded-full outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
                 )}
               >
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "h-2 w-2 rounded-full bg-muted-foreground transition-all duration-200",
+                    isActive
+                      ? "bg-primary scale-200"
+                      : "scale-100 group-hover:bg-foreground/70",
+                  )}
+                />
                 <span className="sr-only">{item.label}</span>
               </a>
             </li>

--- a/src/components/site/DotNav.tsx
+++ b/src/components/site/DotNav.tsx
@@ -1,10 +1,12 @@
 import { navigationItems } from "@/content/landing";
+import { cn } from "@/lib/utils";
 
 type DotNavProps = {
   activeId: string;
+  onNavigate: (id: string) => void;
 };
 
-export function DotNav({ activeId }: DotNavProps) {
+export function DotNav({ activeId, onNavigate }: DotNavProps) {
   return (
     <nav className="fixed right-6 top-1/2 z-40 hidden -translate-y-1/2 lg:block">
       <ul className="flex flex-col gap-3">
@@ -15,7 +17,16 @@ export function DotNav({ activeId }: DotNavProps) {
               <a
                 href={`#${item.id}`}
                 aria-current={isActive ? "true" : undefined}
-                className="block h-2 w-2 rounded-full bg-muted-foreground"
+                onClick={(event) => {
+                  event.preventDefault();
+                  onNavigate(item.id);
+                }}
+                className={cn(
+                  "block rounded-full transition-all duration-200",
+                  isActive
+                    ? "h-4 w-4 bg-primary"
+                    : "h-2 w-2 bg-muted-foreground hover:bg-foreground/70",
+                )}
               >
                 <span className="sr-only">{item.label}</span>
               </a>

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { navigationItems } from "@/content/landing";
 import { cn } from "@/lib/utils";
 
 import { ThemeToggle } from "./ThemeToggle";
+
+const FOCUSABLE_SELECTOR =
+  "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])";
 
 type SiteHeaderProps = {
   activeId: string;
@@ -31,6 +34,7 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
 
   useEffect(() => {
     if (!isMenuOpen) {
+      previousFocusRef.current?.focus();
       return;
     }
 
@@ -40,24 +44,10 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
       return;
     }
 
-    const focusables = panel.querySelectorAll<HTMLElement>(
-      "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])",
+    const focusables = Array.from(
+      panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
     );
     focusables[0]?.focus();
-  }, [isMenuOpen]);
-
-  useEffect(() => {
-    if (isMenuOpen) {
-      return;
-    }
-
-    previousFocusRef.current?.focus();
-  }, [isMenuOpen]);
-
-  useEffect(() => {
-    if (!isMenuOpen) {
-      return;
-    }
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -70,16 +60,8 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
         return;
       }
 
-      const panel = panelRef.current;
-      if (!panel) {
-        return;
-      }
-
-      const focusables = panel.querySelectorAll<HTMLElement>(
-        "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])",
-      );
-
       if (focusables.length === 0) {
+        event.preventDefault();
         return;
       }
 
@@ -97,11 +79,10 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
     };
 
     const onPointerDown = (event: MouseEvent | TouchEvent) => {
-      const panel = panelRef.current;
       const toggleButton = toggleButtonRef.current;
       const target = event.target as Node;
 
-      if (!panel || panel.contains(target) || toggleButton?.contains(target)) {
+      if (panel.contains(target) || toggleButton?.contains(target)) {
         return;
       }
 
@@ -119,10 +100,13 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
     };
   }, [isMenuOpen]);
 
-  const handleNavigate = (id: string) => {
-    onNavigate(id);
-    setIsMenuOpen(false);
-  };
+  const handleNavigate = useCallback(
+    (id: string) => {
+      onNavigate(id);
+      setIsMenuOpen(false);
+    },
+    [onNavigate],
+  );
 
   return (
     <header
@@ -192,7 +176,7 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
         ref={panelRef}
         data-testid="mobile-nav-panel"
         className={cn(
-          "border-t border-border bg-background/95 px-5 py-3 md:hidden",
+          "border-t border-border bg-background/90 px-5 py-3 backdrop-blur md:hidden",
           isMenuOpen ? "block" : "hidden",
         )}
       >

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -1,17 +1,148 @@
+import { useEffect, useRef, useState } from "react";
+
 import { navigationItems } from "@/content/landing";
+import { cn } from "@/lib/utils";
+
+import { ThemeToggle } from "./ThemeToggle";
 
 type SiteHeaderProps = {
   activeId: string;
+  onNavigate: (id: string) => void;
 };
 
-export function SiteHeader({ activeId }: SiteHeaderProps) {
+export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isScrolled, setIsScrolled] = useState(false);
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setIsScrolled(window.scrollY > 80);
+    };
+
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+    if (!panel) {
+      return;
+    }
+
+    const focusables = panel.querySelectorAll<HTMLElement>(
+      "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])",
+    );
+    focusables[0]?.focus();
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (isMenuOpen) {
+      return;
+    }
+
+    previousFocusRef.current?.focus();
+  }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setIsMenuOpen(false);
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const panel = panelRef.current;
+      if (!panel) {
+        return;
+      }
+
+      const focusables = panel.querySelectorAll<HTMLElement>(
+        "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])",
+      );
+
+      if (focusables.length === 0) {
+        return;
+      }
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const activeElement = document.activeElement;
+
+      if (event.shiftKey && activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    const onPointerDown = (event: MouseEvent | TouchEvent) => {
+      const panel = panelRef.current;
+      const toggleButton = toggleButtonRef.current;
+      const target = event.target as Node;
+
+      if (!panel || panel.contains(target) || toggleButton?.contains(target)) {
+        return;
+      }
+
+      setIsMenuOpen(false);
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onPointerDown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+    };
+  }, [isMenuOpen]);
+
+  const handleNavigate = (id: string) => {
+    onNavigate(id);
+    setIsMenuOpen(false);
+  };
+
   return (
     <header
       data-testid="site-header"
-      className="fixed inset-x-0 top-0 z-50 border-b border-transparent bg-background/70 backdrop-blur"
+      className={cn(
+        "fixed inset-x-0 top-0 z-50 transition-colors",
+        isScrolled
+          ? "border-b border-border bg-background/90 backdrop-blur"
+          : "border-b border-transparent bg-background/60",
+      )}
     >
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-5">
-        <a href="#intro" className="font-black tracking-wide">
+        <a
+          href="#intro"
+          onClick={(event) => {
+            event.preventDefault();
+            handleNavigate("intro");
+          }}
+          className="font-black tracking-wide"
+        >
           LIKELION <span className="text-primary">CJU</span>
         </a>
 
@@ -23,7 +154,14 @@ export function SiteHeader({ activeId }: SiteHeaderProps) {
                 key={item.id}
                 href={`#${item.id}`}
                 aria-current={isActive ? "true" : undefined}
-                className="text-xs tracking-[0.15em] uppercase"
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleNavigate(item.id);
+                }}
+                className={cn(
+                  "nav-label text-xs tracking-[0.15em] uppercase transition-colors",
+                  isActive ? "text-primary" : "text-foreground/80 hover:text-foreground",
+                )}
               >
                 {item.label}
               </a>
@@ -31,20 +169,56 @@ export function SiteHeader({ activeId }: SiteHeaderProps) {
           })}
         </nav>
 
-        <button
-          type="button"
-          data-testid="mobile-nav-toggle"
-          className="inline-flex h-9 items-center rounded-md border border-border px-3 text-xs md:hidden"
-          aria-label="Toggle navigation"
-        >
-          Menu
-        </button>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+
+          <button
+            ref={toggleButtonRef}
+            type="button"
+            data-testid="mobile-nav-toggle"
+            className="inline-flex h-9 items-center rounded-md border border-border px-3 text-xs md:hidden"
+            aria-label="Toggle navigation"
+            aria-expanded={isMenuOpen}
+            aria-controls="mobile-menu"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+          >
+            {isMenuOpen ? "Close" : "Menu"}
+          </button>
+        </div>
       </div>
 
       <div
+        id="mobile-menu"
+        ref={panelRef}
         data-testid="mobile-nav-panel"
-        className="hidden border-t border-border px-5 py-3 md:hidden"
-      />
+        className={cn(
+          "border-t border-border px-5 py-3 md:hidden",
+          isMenuOpen ? "block" : "hidden",
+        )}
+      >
+        <nav className="flex flex-col gap-2" aria-label="Mobile primary">
+          {navigationItems.map((item) => {
+            const isActive = item.id === activeId;
+            return (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                aria-current={isActive ? "true" : undefined}
+                className={cn(
+                  "rounded-md px-2 py-2 text-sm",
+                  isActive ? "bg-accent text-accent-foreground" : "text-foreground/80",
+                )}
+                onClick={(event) => {
+                  event.preventDefault();
+                  handleNavigate(item.id);
+                }}
+              >
+                {item.label}
+              </a>
+            );
+          })}
+        </nav>
+      </div>
     </header>
   );
 }

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -129,7 +129,7 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
       data-testid="site-header"
       className={cn(
         "fixed inset-x-0 top-0 z-50 transition-colors",
-        isScrolled
+        isScrolled || isMenuOpen
           ? "border-b border-border bg-background/90 backdrop-blur"
           : "border-b border-transparent bg-background/60",
       )}
@@ -192,7 +192,7 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
         ref={panelRef}
         data-testid="mobile-nav-panel"
         className={cn(
-          "border-t border-border px-5 py-3 md:hidden",
+          "border-t border-border bg-background/95 px-5 py-3 md:hidden",
           isMenuOpen ? "block" : "hidden",
         )}
       >

--- a/src/components/site/ThemeToggle.tsx
+++ b/src/components/site/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+import { useTheme } from "@/hooks/useTheme";
+
+export function ThemeToggle() {
+  const { isDark, toggleTheme } = useTheme();
+
+  return (
+    <button
+      type="button"
+      data-testid="theme-toggle"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+      aria-pressed={isDark}
+      className="inline-flex h-9 items-center rounded-md border border-border px-3 text-xs"
+    >
+      {isDark ? "Light" : "Dark"}
+    </button>
+  );
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -23,14 +23,24 @@ function getStoredTheme(): Theme | null {
   return stored === "dark" || stored === "light" ? stored : null;
 }
 
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  if (document.documentElement.classList.contains("dark")) {
+    return "dark";
+  }
+
+  const stored = getStoredTheme();
+  return stored ?? getSystemTheme();
+}
+
 export function useTheme() {
   const [hasStoredPreference, setHasStoredPreference] = useState(
     () => getStoredTheme() !== null,
   );
-  const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = getStoredTheme();
-    return stored ?? getSystemTheme();
-  });
+  const [theme, setThemeState] = useState<Theme>(() => getInitialTheme());
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", theme === "dark");

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+const STORAGE_KEY = "theme";
+
+function getSystemTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === "dark" || stored === "light" ? stored : null;
+}
+
+export function useTheme() {
+  const [hasStoredPreference, setHasStoredPreference] = useState(
+    () => getStoredTheme() !== null,
+  );
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = getStoredTheme();
+    return stored ?? getSystemTheme();
+  });
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme]);
+
+  useEffect(() => {
+    if (hasStoredPreference) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => {
+      setThemeState(mediaQuery.matches ? "dark" : "light");
+    };
+
+    mediaQuery.addEventListener("change", onChange);
+    return () => {
+      mediaQuery.removeEventListener("change", onChange);
+    };
+  }, [hasStoredPreference]);
+
+  const setTheme = useCallback((nextTheme: Theme) => {
+    setHasStoredPreference(true);
+    setThemeState(nextTheme);
+    localStorage.setItem(STORAGE_KEY, nextTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  }, [setTheme, theme]);
+
+  return {
+    theme,
+    isDark: theme === "dark",
+    setTheme,
+    toggleTheme,
+  };
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 import { AboutSection } from "@/components/sections/AboutSection";
 import { ApplySection } from "@/components/sections/ApplySection";
 import { CurriculumSection } from "@/components/sections/CurriculumSection";
@@ -9,15 +11,42 @@ import { DotNav } from "@/components/site/DotNav";
 import { SiteFooter } from "@/components/site/SiteFooter";
 import { SiteHeader } from "@/components/site/SiteHeader";
 import { sectionOrder } from "@/content/landing";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
+import { scrollToId } from "@/lib/scroll";
 
 export function LandingPage() {
   const activeId = useScrollSpy(sectionOrder);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const didInitialHashScroll = useRef(false);
+
+  useEffect(() => {
+    if (didInitialHashScroll.current) {
+      return;
+    }
+
+    didInitialHashScroll.current = true;
+    const hash = window.location.hash.replace("#", "");
+    if (!hash || !sectionOrder.includes(hash as (typeof sectionOrder)[number])) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      scrollToId(hash, { behavior: "auto", updateHash: false });
+    });
+  }, []);
+
+  const handleNavigate = (id: string) => {
+    scrollToId(id, {
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+      updateHash: true,
+    });
+  };
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <SiteHeader activeId={activeId} />
-      <DotNav activeId={activeId} />
+      <SiteHeader activeId={activeId} onNavigate={handleNavigate} />
+      <DotNav activeId={activeId} onNavigate={handleNavigate} />
 
       <main>
         <IntroSection />


### PR DESCRIPTION
## 변경 사항
- 헤더 상호작용을 구현했습니다: 스크롤 시 헤더 스타일 전환, 데스크탑 active nav 스타일, 모바일 메뉴 열기/닫기.
- 모바일 메뉴 접근성을 구현했습니다: ESC 닫기, 포커스 트랩, 외부 클릭 닫기, 닫힌 뒤 토글 버튼으로 포커스 복귀.
- 런타임 테마 토글을 추가했습니다: `useTheme` + `ThemeToggle` + `localStorage.theme` 저장 + 시스템 테마 fallback.
- DotNav를 active 상태(크기/색상)로 업데이트하고 클릭 내비게이션을 연결했습니다.
- 랜딩 페이지에 초기 해시 스크롤 처리와 reduced-motion 기반 스크롤 동작을 연결했습니다.

## 목적
- Stage 2 목표(스크롤/헤더/모바일 메뉴/테마 런타임/DotNav)를 완료해 Stage 3(실제 섹션 콘텐츠 고도화)의 기반을 만듭니다.

## 검증 방법
- `bun run lint`
- `bun run build`