### PR TITLE
feat(landing): implement landing sections + content model

### DIFF
--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -5,7 +5,7 @@ export function AboutSection() {
   return (
     <section id="about" className="scroll-mt-16 py-24 md:py-32" >
       <div className="relative mb-16 h-[300px] w-full overflow-hidden md:h-[400px]">
-        <img src={aboutContent.imageUrl} alt="Team Collaboration" className="h-full w-full object-cover" />
+        <img src={aboutContent.imageUrl} alt={aboutContent.imageAlt} className="h-full w-full object-cover" />
         <div className="absolute inset-0 bg-gradient-to-t from-white via-white/70 to-transparent dark:from-[#050505] dark:via-[#050505]/70" />
         <div className="absolute inset-0 bg-gradient-to-r from-white/80 to-transparent dark:from-[#050505]/80" />
 

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -1,8 +1,31 @@
+import { Reveal } from "@/components/motion/Reveal";
+import { aboutContent } from "@/content/landing";
+
 export function AboutSection() {
   return (
     <section id="about" className="scroll-mt-16 px-5 py-24">
-      <div className="mx-auto max-w-6xl">
-        <h2 className="text-3xl font-black md:text-5xl">About</h2>
+      <div className="mx-auto grid max-w-6xl gap-10 md:grid-cols-[1.1fr_1fr] md:items-center">
+        <Reveal>
+          <h2 className="text-3xl font-black md:text-5xl">{aboutContent.title}</h2>
+          <p className="mt-4 leading-relaxed text-muted-foreground">{aboutContent.description}</p>
+
+          <div className="mt-7 grid grid-cols-3 gap-3">
+            {aboutContent.stats.map((stat) => (
+              <article key={stat.label} className="rounded-xl border border-border bg-card p-4">
+                <p className="text-xl font-black text-foreground md:text-2xl">{stat.value}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{stat.label}</p>
+              </article>
+            ))}
+          </div>
+        </Reveal>
+
+        <Reveal>
+          <img
+            src={aboutContent.imageUrl}
+            alt="LIKELION CJU members collaborating"
+            className="h-[420px] w-full rounded-2xl border border-border object-cover"
+          />
+        </Reveal>
       </div>
     </section>
   );

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -3,28 +3,53 @@ import { aboutContent } from "@/content/landing";
 
 export function AboutSection() {
   return (
-    <section id="about" className="scroll-mt-16 px-5 py-24">
-      <div className="mx-auto grid max-w-6xl gap-10 md:grid-cols-[1.1fr_1fr] md:items-center">
-        <Reveal>
-          <h2 className="text-3xl font-black md:text-5xl">{aboutContent.title}</h2>
-          <p className="mt-4 leading-relaxed text-muted-foreground">{aboutContent.description}</p>
+    <section id="about" className="scroll-mt-16 py-24 md:py-32" >
+      <div className="relative mb-16 h-[300px] w-full overflow-hidden md:h-[400px]">
+        <img src={aboutContent.imageUrl} alt="Team Collaboration" className="h-full w-full object-cover" />
+        <div className="absolute inset-0 bg-gradient-to-t from-white via-white/70 to-transparent dark:from-[#050505] dark:via-[#050505]/70" />
+        <div className="absolute inset-0 bg-gradient-to-r from-white/80 to-transparent dark:from-[#050505]/80" />
 
-          <div className="mt-7 grid grid-cols-3 gap-3">
-            {aboutContent.stats.map((stat) => (
-              <article key={stat.label} className="rounded-xl border border-border bg-card p-4">
-                <p className="text-xl font-black text-foreground md:text-2xl">{stat.value}</p>
-                <p className="mt-1 text-xs text-muted-foreground">{stat.label}</p>
-              </article>
-            ))}
+        <div className="absolute bottom-8 left-6 md:left-12 lg:left-24">
+          <span className="mb-3 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
+            {aboutContent.label}
+          </span>
+          <h2 className="text-3xl text-foreground dark:text-white md:text-5xl">
+            {aboutContent.titleTop}
+            <br />
+            <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+              {aboutContent.titleAccent}
+            </span>
+          </h2>
+        </div>
+      </div>
+
+      <div className="mx-auto grid max-w-6xl gap-12 px-6 md:grid-cols-2 md:gap-16 md:px-12 lg:px-24">
+        <Reveal>
+          <div className="space-y-6 border-l-2 border-[#FF4D00]/40 pl-6">
+            <p className="text-base leading-relaxed text-foreground/90 dark:text-gray-300 md:text-lg">
+              {aboutContent.paragraphs[0]}
+            </p>
+            <p className="text-sm leading-relaxed text-muted-foreground dark:text-gray-400 md:text-base">
+              {aboutContent.paragraphs[1]}
+            </p>
+            <p className="text-sm leading-relaxed text-muted-foreground dark:text-gray-400 md:text-base">
+              {aboutContent.paragraphs[2]}
+            </p>
           </div>
         </Reveal>
 
         <Reveal>
-          <img
-            src={aboutContent.imageUrl}
-            alt="LIKELION CJU members collaborating"
-            className="h-[420px] w-full rounded-2xl border border-border object-cover"
-          />
+          <div className="grid grid-cols-2 gap-4">
+            {aboutContent.stats.map((stat) => (
+              <article
+                key={stat.label}
+                className="rounded-xl border border-border bg-card p-6 transition-all duration-300 dark:border-white/5 dark:bg-white/[0.02]"
+              >
+                <p className="text-2xl text-foreground dark:text-white md:text-3xl">{stat.value}</p>
+                <p className="mt-1 text-xs text-muted-foreground dark:text-gray-500">{stat.label}</p>
+              </article>
+            ))}
+          </div>
         </Reveal>
       </div>
     </section>

--- a/src/components/sections/ApplySection.tsx
+++ b/src/components/sections/ApplySection.tsx
@@ -3,26 +3,38 @@ import { applyContent } from "@/content/landing";
 
 export function ApplySection() {
   return (
-    <section id="apply" className="scroll-mt-16 px-5 py-24">
-      <div className="mx-auto max-w-6xl">
-        <Reveal>
-          <div className="rounded-3xl border border-border bg-card p-7 md:p-10">
-            <h2 className="text-3xl font-black md:text-5xl">{applyContent.title}</h2>
-            <p className="mt-4 max-w-2xl leading-relaxed text-muted-foreground">
-              {applyContent.description}
-            </p>
-            <p className="mt-3 text-sm font-medium text-primary">{applyContent.period}</p>
+    <section
+      id="apply"
+      className="relative flex min-h-[80vh] flex-col items-center justify-center scroll-mt-16 px-5 py-32 text-center md:py-40"
+    >
+      <div className="absolute inset-0 overflow-hidden">
+        <div className="absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#FF4D00]/5 blur-[120px]" />
+      </div>
 
-            <a
-              data-testid="apply-cta"
-              href={applyContent.ctaHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-7 inline-flex rounded-full bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
-            >
-              {applyContent.ctaLabel}
-            </a>
+      <div className="relative z-10 mx-auto max-w-6xl px-6">
+        <Reveal>
+          <div className="mb-6 flex items-center justify-center gap-2 text-[#FF4D00]">
+            <span className="text-xs">*</span>
+            <span className="text-xs tracking-[0.3em] uppercase">{applyContent.recruitLabel}</span>
+            <span className="text-xs">*</span>
           </div>
+
+          <h2 className="mb-4 text-4xl tracking-tight text-foreground dark:text-white sm:text-5xl md:text-7xl">
+            {applyContent.titleTop} <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">{applyContent.titleAccent}</span>
+          </h2>
+
+          <a
+            data-testid="apply-cta"
+            href={applyContent.ctaHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-3 rounded-full bg-[#FF4D00] px-10 py-4 text-sm tracking-wider text-white uppercase shadow-lg transition-all duration-300 hover:bg-[#FF6A2B] hover:shadow-[#FF4D00]/20"
+          >
+            {applyContent.ctaLabel}
+            <span>{"->"}</span>
+          </a>
+
+          <p className="mt-6 text-xs text-muted-foreground dark:text-gray-600">{applyContent.period}</p>
         </Reveal>
       </div>
     </section>

--- a/src/components/sections/ApplySection.tsx
+++ b/src/components/sections/ApplySection.tsx
@@ -1,4 +1,5 @@
 import { Reveal } from "@/components/motion/Reveal";
+import { Sparkles, ArrowRight } from "lucide-react";
 import { applyContent } from "@/content/landing";
 
 export function ApplySection() {
@@ -14,9 +15,9 @@ export function ApplySection() {
       <div className="relative z-10 mx-auto max-w-6xl px-6">
         <Reveal>
           <div className="mb-6 flex items-center justify-center gap-2 text-[#FF4D00]">
-            <span className="text-xs">*</span>
+            <Sparkles className="h-4 w-4" />
             <span className="text-xs tracking-[0.3em] uppercase">{applyContent.recruitLabel}</span>
-            <span className="text-xs">*</span>
+            <Sparkles className="h-4 w-4" />
           </div>
 
           <h2 className="mb-4 text-4xl tracking-tight text-foreground dark:text-white sm:text-5xl md:text-7xl">
@@ -31,7 +32,7 @@ export function ApplySection() {
             className="inline-flex items-center gap-3 rounded-full bg-[#FF4D00] px-10 py-4 text-sm tracking-wider text-white uppercase shadow-lg transition-all duration-300 hover:bg-[#FF6A2B] hover:shadow-[#FF4D00]/20"
           >
             {applyContent.ctaLabel}
-            <span>{"->"}</span>
+            <ArrowRight className="h-5 w-5" />
           </a>
 
           <p className="mt-6 text-xs text-muted-foreground dark:text-gray-600">{applyContent.period}</p>

--- a/src/components/sections/ApplySection.tsx
+++ b/src/components/sections/ApplySection.tsx
@@ -1,17 +1,29 @@
+import { Reveal } from "@/components/motion/Reveal";
+import { applyContent } from "@/content/landing";
+
 export function ApplySection() {
   return (
     <section id="apply" className="scroll-mt-16 px-5 py-24">
       <div className="mx-auto max-w-6xl">
-        <h2 className="mb-6 text-3xl font-black md:text-5xl">Apply</h2>
-        <a
-          data-testid="apply-cta"
-          href="https://forms.gle/7M8Dfxv63tGuSEJ56"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex rounded-full bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
-        >
-          14기 지원하러 가기
-        </a>
+        <Reveal>
+          <div className="rounded-3xl border border-border bg-card p-7 md:p-10">
+            <h2 className="text-3xl font-black md:text-5xl">{applyContent.title}</h2>
+            <p className="mt-4 max-w-2xl leading-relaxed text-muted-foreground">
+              {applyContent.description}
+            </p>
+            <p className="mt-3 text-sm font-medium text-primary">{applyContent.period}</p>
+
+            <a
+              data-testid="apply-cta"
+              href={applyContent.ctaHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-7 inline-flex rounded-full bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+            >
+              {applyContent.ctaLabel}
+            </a>
+          </div>
+        </Reveal>
       </div>
     </section>
   );

--- a/src/components/sections/CurriculumSection.tsx
+++ b/src/components/sections/CurriculumSection.tsx
@@ -3,32 +3,54 @@ import { curriculumContent } from "@/content/landing";
 
 export function CurriculumSection() {
   return (
-    <section id="curriculum" className="scroll-mt-16 px-5 py-24">
+    <section id="curriculum" className="min-h-screen scroll-mt-16 bg-background dark:bg-[#0A0A0A] px-5 py-24 md:py-32">
       <div className="mx-auto max-w-6xl">
         <Reveal>
-          <h2 className="text-3xl font-black md:text-5xl">{curriculumContent.title}</h2>
+          <div className="mb-16 text-center">
+            <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
+              {curriculumContent.label}
+            </span>
+            <h2 className="text-3xl text-foreground dark:text-white md:text-5xl">
+              {curriculumContent.titleTop}{" "}
+              <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+                {curriculumContent.titleAccent}
+              </span>
+            </h2>
+          </div>
         </Reveal>
 
-        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {curriculumContent.tracks.map((track) => (
-            <Reveal key={track.title}>
-              <article className="h-full rounded-2xl border border-border bg-card p-5">
-                <h3 className="text-lg font-bold text-foreground">{track.title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                  {track.description}
-                </p>
+        <div className="mx-auto grid max-w-6xl gap-6 lg:grid-cols-3">
+          {curriculumContent.groups.map((group) => (
+            <Reveal key={group.name}>
+              <section className="rounded-2xl border border-border bg-card p-5 transition-colors dark:border-white/5 dark:bg-white/[0.02]">
+                <header className="mb-4 border-b border-border pb-3 dark:border-white/10">
+                  <h3 className="text-base font-semibold text-foreground dark:text-white">
+                    {group.name}
+                  </h3>
+                  <p className="mt-1 text-[11px] tracking-[0.15em] text-[#FF4D00] uppercase">
+                    {group.subtitle}
+                  </p>
+                </header>
 
-                <ul className="mt-4 flex flex-wrap gap-2">
-                  {track.skills.map((skill) => (
-                    <li
-                      key={skill}
-                      className="rounded-full border border-border bg-background px-3 py-1 text-xs text-foreground/90"
+                <div className="space-y-3">
+                  {group.items.map((item) => (
+                    <article
+                      key={item.title}
+                      className="group rounded-xl border border-border bg-background p-4 transition-all duration-300 hover:-translate-y-0.5 hover:border-[#FF4D00]/30 dark:border-white/8 dark:bg-black/20"
                     >
-                      {skill}
-                    </li>
+                      <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-[#FF4D00]/6 text-muted-foreground transition-colors duration-300 group-hover:text-[#FF4D00] dark:text-gray-500">
+                        <span className="text-xs">*</span>
+                      </div>
+                      <h4 className="mb-2 text-sm font-semibold text-foreground transition-colors duration-300 group-hover:text-[#FF4D00] dark:text-white">
+                        {item.title}
+                      </h4>
+                      <p className="text-xs leading-relaxed text-muted-foreground dark:text-gray-400">
+                        {item.desc}
+                      </p>
+                    </article>
                   ))}
-                </ul>
-              </article>
+                </div>
+              </section>
             </Reveal>
           ))}
         </div>

--- a/src/components/sections/CurriculumSection.tsx
+++ b/src/components/sections/CurriculumSection.tsx
@@ -1,8 +1,37 @@
+import { Reveal } from "@/components/motion/Reveal";
+import { curriculumContent } from "@/content/landing";
+
 export function CurriculumSection() {
   return (
     <section id="curriculum" className="scroll-mt-16 px-5 py-24">
       <div className="mx-auto max-w-6xl">
-        <h2 className="text-3xl font-black md:text-5xl">Curriculum</h2>
+        <Reveal>
+          <h2 className="text-3xl font-black md:text-5xl">{curriculumContent.title}</h2>
+        </Reveal>
+
+        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {curriculumContent.tracks.map((track) => (
+            <Reveal key={track.title}>
+              <article className="h-full rounded-2xl border border-border bg-card p-5">
+                <h3 className="text-lg font-bold text-foreground">{track.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {track.description}
+                </p>
+
+                <ul className="mt-4 flex flex-wrap gap-2">
+                  {track.skills.map((skill) => (
+                    <li
+                      key={skill}
+                      className="rounded-full border border-border bg-background px-3 py-1 text-xs text-foreground/90"
+                    >
+                      {skill}
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            </Reveal>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/sections/CurriculumSection.tsx
+++ b/src/components/sections/CurriculumSection.tsx
@@ -1,5 +1,16 @@
 import { Reveal } from "@/components/motion/Reveal";
+import { Code, LayoutTemplate, Server, Database, PenTool, Bot } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { curriculumContent } from "@/content/landing";
+
+const TRACK_ICONS: Record<string, LucideIcon> = {
+  "HTML/CSS & JS": Code,
+  "React & Frontend": LayoutTemplate,
+  "Python & Django": Server,
+  "Database & API": Database,
+  "UI/UX Design": PenTool,
+  "AI Convergence": Bot,
+};
 
 export function CurriculumSection() {
   return (
@@ -33,22 +44,25 @@ export function CurriculumSection() {
                 </header>
 
                 <div className="space-y-3">
-                  {group.items.map((item) => (
-                    <article
-                      key={item.title}
-                      className="group rounded-xl border border-border bg-background p-4 transition-all duration-300 hover:-translate-y-0.5 hover:border-[#FF4D00]/30 dark:border-white/8 dark:bg-black/20"
-                    >
-                      <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-[#FF4D00]/6 text-muted-foreground transition-colors duration-300 group-hover:text-[#FF4D00] dark:text-gray-500">
-                        <span className="text-xs">*</span>
-                      </div>
-                      <h4 className="mb-2 text-sm font-semibold text-foreground transition-colors duration-300 group-hover:text-[#FF4D00] dark:text-white">
-                        {item.title}
-                      </h4>
-                      <p className="text-xs leading-relaxed text-muted-foreground dark:text-gray-400">
-                        {item.desc}
-                      </p>
-                    </article>
-                  ))}
+                  {group.items.map((item) => {
+                    const Icon = TRACK_ICONS[item.title] || Code;
+                    return (
+                      <article
+                        key={item.title}
+                        className="group rounded-xl border border-border bg-background p-4 transition-all duration-300 hover:-translate-y-0.5 hover:border-[#FF4D00]/30 dark:border-white/8 dark:bg-black/20"
+                      >
+                        <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-[#FF4D00]/6 text-muted-foreground transition-colors duration-300 group-hover:text-[#FF4D00] dark:text-gray-500">
+                          <Icon className="h-5 w-5" />
+                        </div>
+                        <h4 className="mb-2 text-sm font-semibold text-foreground transition-colors duration-300 group-hover:text-[#FF4D00] dark:text-white">
+                          {item.title}
+                        </h4>
+                        <p className="text-xs leading-relaxed text-muted-foreground dark:text-gray-400">
+                          {item.desc}
+                        </p>
+                      </article>
+                    )
+                  })}
                 </div>
               </section>
             </Reveal>

--- a/src/components/sections/IntroSection.tsx
+++ b/src/components/sections/IntroSection.tsx
@@ -1,23 +1,48 @@
 import { Reveal } from "@/components/motion/Reveal";
+import { introContent } from "@/content/landing";
 
 export function IntroSection() {
   return (
     <section
       id="intro"
-      className="min-h-screen scroll-mt-16 bg-background px-5 pb-20 pt-28"
+      className="relative min-h-screen scroll-mt-16 overflow-hidden bg-background px-5 pb-20 pt-28"
     >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,77,0,0.15),transparent_45%)]" />
+      <div className="pointer-events-none absolute inset-0 [background-image:linear-gradient(to_right,transparent_0,transparent_39px,rgba(255,255,255,0.04)_40px),linear-gradient(to_bottom,transparent_0,transparent_39px,rgba(255,255,255,0.04)_40px)] [background-size:40px_40px]" />
+
       <div className="mx-auto max-w-6xl">
-        <Reveal>
+        <Reveal className="relative z-10">
           <p className="mb-4 text-xs tracking-[0.25em] text-primary uppercase">
-            LIKELION 14TH GENERATION @ CJU
+            {introContent.badge}
           </p>
           <h1 className="text-4xl font-black tracking-tight text-foreground md:text-7xl">
-            BUILD YOUR
+            {introContent.titleTop}
             <br />
             <span className="bg-gradient-to-r from-[var(--brand-500)] to-[var(--brand-400)] bg-clip-text text-transparent">
-              OWN UNIVERSE
+              {introContent.titleAccent}
             </span>
           </h1>
+
+          <p className="mt-6 max-w-2xl text-base leading-relaxed text-muted-foreground md:text-lg">
+            {introContent.description}
+          </p>
+
+          <div className="mt-8 flex flex-wrap gap-3">
+            <a
+              href={introContent.primaryCta.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex rounded-full bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+            >
+              {introContent.primaryCta.label}
+            </a>
+            <a
+              href={`#${introContent.secondaryCta.targetId}`}
+              className="inline-flex rounded-full border border-border bg-card px-6 py-3 text-sm font-semibold text-card-foreground"
+            >
+              {introContent.secondaryCta.label}
+            </a>
+          </div>
         </Reveal>
       </div>
     </section>

--- a/src/components/sections/IntroSection.tsx
+++ b/src/components/sections/IntroSection.tsx
@@ -5,17 +5,32 @@ export function IntroSection() {
   return (
     <section
       id="intro"
-      className="relative min-h-screen scroll-mt-16 overflow-hidden bg-background px-5 pb-20 pt-28"
+      className="relative flex min-h-screen items-center justify-center scroll-mt-16 overflow-hidden bg-background"
     >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(255,77,0,0.15),transparent_45%)]" />
-      <div className="pointer-events-none absolute inset-0 [background-image:linear-gradient(to_right,transparent_0,transparent_39px,rgba(255,255,255,0.04)_40px),linear-gradient(to_bottom,transparent_0,transparent_39px,rgba(255,255,255,0.04)_40px)] [background-size:40px_40px]" />
+      <div className="absolute inset-0 z-0">
+        <img
+          src={introContent.backgroundImage}
+          alt="Coding Background"
+          className="h-full w-full object-cover opacity-30"
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-white/70 via-white/45 to-white dark:from-[#050505]/60 dark:via-[#050505]/40 dark:to-[#050505]" />
+        <div
+          className="absolute inset-0 opacity-[0.03]"
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(255,77,0,0.3) 1px, transparent 1px), linear-gradient(90deg, rgba(255,77,0,0.3) 1px, transparent 1px)",
+            backgroundSize: "60px 60px",
+          }}
+        />
+      </div>
 
-      <div className="mx-auto max-w-6xl">
-        <Reveal className="relative z-10">
-          <p className="mb-4 text-xs tracking-[0.25em] text-primary uppercase">
+      <div className="relative z-10 mx-[0px] my-[50px] flex flex-col items-center px-[24px] py-[50px] text-center">
+        <Reveal>
+          <span className="mb-8 inline-block rounded-full border border-[#FF4D00]/30 px-4 py-1.5 text-xs tracking-[0.25em] text-[#FF4D00] uppercase">
             {introContent.badge}
-          </p>
-          <h1 className="text-4xl font-black tracking-tight text-foreground md:text-7xl">
+          </span>
+
+          <h1 className="mb-8 text-5xl tracking-tight text-foreground dark:text-white sm:text-6xl md:text-8xl lg:text-9xl">
             {introContent.titleTop}
             <br />
             <span className="bg-gradient-to-r from-[var(--brand-500)] to-[var(--brand-400)] bg-clip-text text-transparent">
@@ -23,26 +38,29 @@ export function IntroSection() {
             </span>
           </h1>
 
-          <p className="mt-6 max-w-2xl text-base leading-relaxed text-muted-foreground md:text-lg">
-            {introContent.description}
+          <p className="mx-auto mb-12 max-w-xl text-base leading-relaxed text-muted-foreground dark:text-gray-400 sm:text-lg md:text-xl">
+            {introContent.descriptionTop}
+            <br />
+            <span className="text-foreground dark:text-white">{introContent.descriptionStrong}</span>
+            {introContent.descriptionBottom}
           </p>
 
-          <div className="mt-8 flex flex-wrap gap-3">
+          <div className="mb-20 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
-              href={introContent.primaryCta.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex rounded-full bg-primary px-6 py-3 text-sm font-bold text-primary-foreground"
+              href={`#${introContent.primaryCta.targetId}`}
+              className="inline-flex cursor-pointer rounded-full bg-[#FF4D00] px-8 py-3.5 text-sm tracking-wider text-white uppercase transition-all duration-300 hover:bg-[#FF6A2B] hover:shadow-lg hover:shadow-[#FF4D00]/20"
             >
               {introContent.primaryCta.label}
             </a>
-            <a
-              href={`#${introContent.secondaryCta.targetId}`}
-              className="inline-flex rounded-full border border-border bg-card px-6 py-3 text-sm font-semibold text-card-foreground"
-            >
-              {introContent.secondaryCta.label}
-            </a>
           </div>
+
+          <a
+            href="#vision"
+            className="flex cursor-pointer flex-col items-center text-muted-foreground dark:text-gray-500 transition-colors hover:text-[#FF4D00]"
+          >
+            <span className="mb-2 text-[10px] tracking-[0.3em] uppercase">Scroll Down</span>
+            <span className="text-sm">v</span>
+          </a>
         </Reveal>
       </div>
     </section>

--- a/src/components/sections/IntroSection.tsx
+++ b/src/components/sections/IntroSection.tsx
@@ -1,4 +1,5 @@
 import { Reveal } from "@/components/motion/Reveal";
+import { ChevronDown } from "lucide-react";
 import { introContent } from "@/content/landing";
 
 export function IntroSection() {
@@ -59,7 +60,7 @@ export function IntroSection() {
             className="flex cursor-pointer flex-col items-center text-muted-foreground dark:text-gray-500 transition-colors hover:text-[#FF4D00]"
           >
             <span className="mb-2 text-[10px] tracking-[0.3em] uppercase">Scroll Down</span>
-            <span className="text-sm">v</span>
+            <ChevronDown className="h-5 w-5 animate-bounce" />
           </a>
         </Reveal>
       </div>

--- a/src/components/sections/RoadmapSection.tsx
+++ b/src/components/sections/RoadmapSection.tsx
@@ -1,5 +1,15 @@
 import { Reveal } from "@/components/motion/Reveal";
+import { Flag, TrendingUp, Lightbulb, Rocket, Globe } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { roadmapContent } from "@/content/landing";
+
+const PHASE_ICONS: Record<string, LucideIcon> = {
+  "The Beginning": Flag,
+  "Growth": TrendingUp,
+  "Ideathon": Lightbulb,
+  "Hackathon": Rocket,
+  "Expansion": Globe,
+};
 
 export function RoadmapSection() {
   return (
@@ -84,14 +94,16 @@ export function RoadmapSection() {
 
                   <div className="absolute top-0 left-0 z-10 md:left-1/2 md:-translate-x-1/2">
                     <div
-                      className="flex h-8 w-8 items-center justify-center rounded-full border-2"
+                      className="flex h-8 w-8 items-center justify-center rounded-full border-2 bg-card"
                       style={{
-                        backgroundColor: "var(--card)",
                         borderColor: item.color,
                         color: item.color,
                       }}
                     >
-                      <span className="text-xs">*</span>
+                      {(() => {
+                        const Icon = PHASE_ICONS[item.title] || Flag;
+                        return <Icon className="h-4 w-4" />;
+                      })()}
                     </div>
                   </div>
 

--- a/src/components/sections/RoadmapSection.tsx
+++ b/src/components/sections/RoadmapSection.tsx
@@ -3,30 +3,103 @@ import { roadmapContent } from "@/content/landing";
 
 export function RoadmapSection() {
   return (
-    <section id="roadmap" className="scroll-mt-16 bg-card px-5 py-24">
-      <div className="mx-auto max-w-6xl">
+    <section id="roadmap" className="relative scroll-mt-16 px-5 py-24 md:py-32">
+      <div className="mx-auto max-w-4xl">
         <Reveal>
-          <h2 className="text-3xl font-black md:text-5xl">{roadmapContent.title}</h2>
+          <div className="relative z-10 mb-16 text-center">
+            <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
+              {roadmapContent.label}
+            </span>
+            <h2 className="text-3xl text-foreground dark:text-white md:text-5xl">
+              {roadmapContent.titleTop}{" "}
+              <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+                {roadmapContent.titleAccent}
+              </span>
+            </h2>
+          </div>
         </Reveal>
 
-        <div className="mt-10 space-y-4">
-          {roadmapContent.items.map((item, index) => (
-            <Reveal key={`${item.month}-${item.title}`}>
-              <article className="grid items-center gap-4 rounded-2xl border border-border bg-background/70 p-5 md:grid-cols-[80px_1fr]">
-                <div className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary text-sm font-bold text-primary-foreground">
-                  {item.month}
-                </div>
+        <div className="relative mx-auto max-w-4xl">
+          <div className="absolute top-0 bottom-0 left-4 w-px bg-gradient-to-b from-transparent via-border to-transparent dark:via-white/10 md:hidden" />
 
-                <div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-lg font-bold text-foreground">{item.title}</p>
-                    <span className="text-xs text-muted-foreground">Step {index + 1}</span>
+          <div className="relative z-10 space-y-8">
+            {roadmapContent.items.map((item, index) => (
+              <Reveal key={`${item.period}-${item.title}`}>
+                <article
+                  className={`relative flex items-start gap-6 md:gap-0 ${index % 2 === 0 ? "md:flex-row" : "md:flex-row-reverse"
+                    }`}
+                >
+                  {/* Desktop Connection Line SVG */}
+                  {index < roadmapContent.items.length - 1 && (
+                    <div className="pointer-events-none absolute top-8 -bottom-8 left-0 z-0 hidden w-full md:block">
+                      <svg
+                        className="h-full w-full text-foreground/35 dark:text-white/18"
+                        viewBox="0 0 832 100"
+                        preserveAspectRatio="none"
+                        style={{ overflow: "visible" }}
+                      >
+                        <path
+                          d={
+                            index % 2 === 0
+                              ? "M 416 0 C 556 20, 318 80, 416 100"
+                              : "M 416 0 C 256 20, 528 80, 416 100"
+                          }
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          strokeDasharray={index % 2 === 0 ? "8 5 3 7" : "5 6 8 4"}
+                          strokeLinecap="round"
+                        />
+                      </svg>
+                    </div>
+                  )}
+
+                  <div
+                    className={`pl-10 md:w-[calc(50%-2rem)] md:pl-0 ${index % 2 === 0 ? "md:pr-8 md:text-right" : "md:pl-8 md:text-left"
+                      }`}
+                  >
+                    <span
+                      className="mb-1 block text-xs tracking-[0.2em] uppercase"
+                      style={{ color: item.color }}
+                    >
+                      {item.period}
+                    </span>
+                    <h3 className="mb-3 text-lg text-foreground dark:text-white md:text-xl">{item.title}</h3>
+                    <ul className="space-y-1.5">
+                      {item.items.map((desc) => (
+                        <li
+                          key={desc}
+                          className="flex items-center gap-2 text-xs text-muted-foreground dark:text-gray-500"
+                          style={{
+                            justifyContent: index % 2 === 0 ? "flex-end" : "flex-start",
+                          }}
+                        >
+                          <span className="hidden h-1 w-1 shrink-0 rounded-full bg-muted-foreground dark:bg-gray-600 md:inline" />
+                          <span>{desc}</span>
+                          <span className="order-first h-1 w-1 shrink-0 rounded-full bg-muted-foreground dark:bg-gray-600 md:hidden" />
+                        </li>
+                      ))}
+                    </ul>
                   </div>
-                  <p className="mt-1 text-sm text-muted-foreground">{item.detail}</p>
-                </div>
-              </article>
-            </Reveal>
-          ))}
+
+                  <div className="absolute top-0 left-0 z-10 md:left-1/2 md:-translate-x-1/2">
+                    <div
+                      className="flex h-8 w-8 items-center justify-center rounded-full border-2"
+                      style={{
+                        backgroundColor: "var(--card)",
+                        borderColor: item.color,
+                        color: item.color,
+                      }}
+                    >
+                      <span className="text-xs">*</span>
+                    </div>
+                  </div>
+
+                  <div className="hidden md:block md:w-[calc(50%-2rem)]" />
+                </article>
+              </Reveal>
+            ))}
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/sections/RoadmapSection.tsx
+++ b/src/components/sections/RoadmapSection.tsx
@@ -1,8 +1,33 @@
+import { Reveal } from "@/components/motion/Reveal";
+import { roadmapContent } from "@/content/landing";
+
 export function RoadmapSection() {
   return (
     <section id="roadmap" className="scroll-mt-16 bg-card px-5 py-24">
       <div className="mx-auto max-w-6xl">
-        <h2 className="text-3xl font-black md:text-5xl">Roadmap</h2>
+        <Reveal>
+          <h2 className="text-3xl font-black md:text-5xl">{roadmapContent.title}</h2>
+        </Reveal>
+
+        <div className="mt-10 space-y-4">
+          {roadmapContent.items.map((item, index) => (
+            <Reveal key={`${item.month}-${item.title}`}>
+              <article className="grid items-center gap-4 rounded-2xl border border-border bg-background/70 p-5 md:grid-cols-[80px_1fr]">
+                <div className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary text-sm font-bold text-primary-foreground">
+                  {item.month}
+                </div>
+
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-lg font-bold text-foreground">{item.title}</p>
+                    <span className="text-xs text-muted-foreground">Step {index + 1}</span>
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">{item.detail}</p>
+                </div>
+              </article>
+            </Reveal>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/sections/TeamSection.tsx
+++ b/src/components/sections/TeamSection.tsx
@@ -1,4 +1,5 @@
 import { Reveal } from "@/components/motion/Reveal";
+import { User, Users } from "lucide-react";
 import { teamContent } from "@/content/landing";
 
 function MemberCard({ name, role, desc }: { name: string; role?: string; desc: string }) {
@@ -6,7 +7,7 @@ function MemberCard({ name, role, desc }: { name: string; role?: string; desc: s
     <article className="group rounded-xl border border-border bg-card p-5 transition-all duration-300 hover:border-[#FF4D00]/30 dark:border-white/5 dark:bg-white/[0.02]">
       <div className="mb-3 flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#FF4D00]/10 text-[#FF4D00]">
-          <span className="text-xs">*</span>
+          <User className="h-5 w-5" />
         </div>
         <div>
           <h4 className="text-sm text-foreground dark:text-white">{name}</h4>
@@ -50,7 +51,9 @@ export function TeamSection() {
             <Reveal key={department.name}>
               <section>
                 <div className="mb-4 flex items-center gap-2 border-b border-border pb-2 dark:border-white/5">
-                  <span className="text-xs text-[#FF4D00]">*</span>
+                  <span className="text-xs text-[#FF4D00]">
+                    <Users className="h-4 w-4" />
+                  </span>
                   <h3 className="text-sm tracking-wider text-foreground dark:text-white">{department.name}</h3>
                 </div>
                 <div className="space-y-3">

--- a/src/components/sections/TeamSection.tsx
+++ b/src/components/sections/TeamSection.tsx
@@ -1,23 +1,64 @@
 import { Reveal } from "@/components/motion/Reveal";
 import { teamContent } from "@/content/landing";
 
+function MemberCard({ name, role, desc }: { name: string; role?: string; desc: string }) {
+  return (
+    <article className="group rounded-xl border border-border bg-card p-5 transition-all duration-300 hover:border-[#FF4D00]/30 dark:border-white/5 dark:bg-white/[0.02]">
+      <div className="mb-3 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#FF4D00]/10 text-[#FF4D00]">
+          <span className="text-xs">*</span>
+        </div>
+        <div>
+          <h4 className="text-sm text-foreground dark:text-white">{name}</h4>
+          {role ? <p className="text-xs text-[#FF4D00]">{role}</p> : null}
+        </div>
+      </div>
+      <p className="text-xs leading-relaxed text-muted-foreground dark:text-gray-500">{desc}</p>
+    </article>
+  );
+}
+
 export function TeamSection() {
   return (
-    <section id="team" className="scroll-mt-16 bg-card px-5 py-24">
+    <section id="team" className="min-h-screen scroll-mt-16 bg-background px-5 py-24 md:py-32">
       <div className="mx-auto max-w-6xl">
         <Reveal>
-          <h2 className="text-3xl font-black md:text-5xl">{teamContent.title}</h2>
-          <p className="mt-3 text-muted-foreground">{teamContent.description}</p>
+          <div className="mb-16 text-center">
+            <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
+              {teamContent.label}
+            </span>
+            <h2 className="mb-4 text-3xl text-foreground dark:text-white md:text-5xl">
+              {teamContent.titleTop}{" "}
+              <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+                {teamContent.titleAccent}
+              </span>
+            </h2>
+            <p className="mx-auto max-w-md text-sm text-muted-foreground dark:text-gray-500">{teamContent.subtitle}</p>
+          </div>
         </Reveal>
 
-        <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {teamContent.members.map((member) => (
+        <div className="mx-auto mb-12 grid max-w-xl gap-4 md:grid-cols-2">
+          {teamContent.leaders.map((member) => (
             <Reveal key={`${member.role}-${member.name}`}>
-              <article className="rounded-2xl border border-border bg-background/70 p-5">
-                <p className="text-xs tracking-[0.2em] text-primary uppercase">{member.role}</p>
-                <h3 className="mt-2 text-xl font-bold text-foreground">{member.name}</h3>
-                <p className="mt-1 text-sm text-muted-foreground">{member.part}</p>
-              </article>
+              <MemberCard name={member.name} role={member.role} desc={member.desc} />
+            </Reveal>
+          ))}
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-3">
+          {teamContent.departments.map((department) => (
+            <Reveal key={department.name}>
+              <section>
+                <div className="mb-4 flex items-center gap-2 border-b border-border pb-2 dark:border-white/5">
+                  <span className="text-xs text-[#FF4D00]">*</span>
+                  <h3 className="text-sm tracking-wider text-foreground dark:text-white">{department.name}</h3>
+                </div>
+                <div className="space-y-3">
+                  {department.members.map((member) => (
+                    <MemberCard key={member.name} name={member.name} desc={member.desc} />
+                  ))}
+                </div>
+              </section>
             </Reveal>
           ))}
         </div>

--- a/src/components/sections/TeamSection.tsx
+++ b/src/components/sections/TeamSection.tsx
@@ -1,8 +1,26 @@
+import { Reveal } from "@/components/motion/Reveal";
+import { teamContent } from "@/content/landing";
+
 export function TeamSection() {
   return (
     <section id="team" className="scroll-mt-16 bg-card px-5 py-24">
       <div className="mx-auto max-w-6xl">
-        <h2 className="text-3xl font-black md:text-5xl">Team</h2>
+        <Reveal>
+          <h2 className="text-3xl font-black md:text-5xl">{teamContent.title}</h2>
+          <p className="mt-3 text-muted-foreground">{teamContent.description}</p>
+        </Reveal>
+
+        <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {teamContent.members.map((member) => (
+            <Reveal key={`${member.role}-${member.name}`}>
+              <article className="rounded-2xl border border-border bg-background/70 p-5">
+                <p className="text-xs tracking-[0.2em] text-primary uppercase">{member.role}</p>
+                <h3 className="mt-2 text-xl font-bold text-foreground">{member.name}</h3>
+                <p className="mt-1 text-sm text-muted-foreground">{member.part}</p>
+              </article>
+            </Reveal>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/sections/VisionSection.tsx
+++ b/src/components/sections/VisionSection.tsx
@@ -1,5 +1,15 @@
 import { Reveal } from "@/components/motion/Reveal";
+import { Telescope, BookOpen, Share2, Wrench, Flame } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { visionContent } from "@/content/landing";
+
+const PILLAR_ICONS: Record<string, LucideIcon> = {
+  Discover: Telescope,
+  Learn: BookOpen,
+  Share: Share2,
+  Build: Wrench,
+  Impact: Flame,
+};
 
 export function VisionSection() {
   return (
@@ -24,19 +34,22 @@ export function VisionSection() {
           <div className="absolute top-[1.75rem] left-[10%] right-[10%] hidden h-px bg-border dark:bg-[#FF4D00]/30 md:block" />
 
           <div className="grid grid-cols-2 gap-6 md:grid-cols-5 md:gap-4">
-            {visionContent.pillars.map((pillar) => (
-              <Reveal key={pillar.label} className="flex flex-col items-center text-center">
-                <div className="relative z-10 mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-border bg-card text-muted-foreground dark:border-gray-700 dark:bg-[#0A0A0A] dark:text-gray-500 transition-all duration-300">
-                  <span className="text-xs">*</span>
-                </div>
-                <h3 className="mb-2 text-sm tracking-wider text-foreground dark:text-white uppercase transition-colors">
-                  {pillar.label}
-                </h3>
-                <p className="whitespace-pre-line text-xs leading-relaxed text-muted-foreground dark:text-gray-500">
-                  {pillar.desc}
-                </p>
-              </Reveal>
-            ))}
+            {visionContent.pillars.map((pillar) => {
+              const Icon = PILLAR_ICONS[pillar.label] || Telescope;
+              return (
+                <Reveal key={pillar.label} className="flex flex-col items-center text-center">
+                  <div className="relative z-10 mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-border bg-card text-muted-foreground dark:border-gray-700 dark:bg-[#0A0A0A] dark:text-gray-500 transition-all duration-300">
+                    <Icon className="h-6 w-6" />
+                  </div>
+                  <h3 className="mb-2 text-sm tracking-wider text-foreground dark:text-white uppercase transition-colors">
+                    {pillar.label}
+                  </h3>
+                  <p className="whitespace-pre-line text-xs leading-relaxed text-muted-foreground dark:text-gray-500">
+                    {pillar.desc}
+                  </p>
+                </Reveal>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/src/components/sections/VisionSection.tsx
+++ b/src/components/sections/VisionSection.tsx
@@ -1,8 +1,29 @@
+import { Reveal } from "@/components/motion/Reveal";
+import { visionContent } from "@/content/landing";
+
 export function VisionSection() {
   return (
     <section id="vision" className="scroll-mt-16 bg-card px-5 py-24">
       <div className="mx-auto max-w-6xl">
-        <h2 className="text-3xl font-black md:text-5xl">Our Vision</h2>
+        <Reveal>
+          <h2 className="text-3xl font-black md:text-5xl">{visionContent.title}</h2>
+          <p className="mt-3 text-muted-foreground">{visionContent.subtitle}</p>
+        </Reveal>
+
+        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          {visionContent.pillars.map((pillar) => (
+            <Reveal key={pillar.title} className="h-full">
+              <article className="h-full rounded-2xl border border-border bg-background/70 p-5">
+                <h3 className="text-sm font-bold tracking-wide text-primary uppercase">
+                  {pillar.title}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                  {pillar.description}
+                </p>
+              </article>
+            </Reveal>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/sections/VisionSection.tsx
+++ b/src/components/sections/VisionSection.tsx
@@ -3,26 +3,41 @@ import { visionContent } from "@/content/landing";
 
 export function VisionSection() {
   return (
-    <section id="vision" className="scroll-mt-16 bg-card px-5 py-24">
-      <div className="mx-auto max-w-6xl">
+    <section id="vision" className="min-h-screen scroll-mt-16 bg-background dark:bg-[#0A0A0A] px-5 py-24 md:py-32">
+      <div className="mx-auto max-w-5xl">
         <Reveal>
-          <h2 className="text-3xl font-black md:text-5xl">{visionContent.title}</h2>
-          <p className="mt-3 text-muted-foreground">{visionContent.subtitle}</p>
+          <div className="mb-16 text-center md:mb-20">
+            <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
+              {visionContent.label}
+            </span>
+            <h2 className="text-3xl text-foreground dark:text-white md:text-5xl">
+              {visionContent.titleTop}
+              <br />
+              <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+                {visionContent.titleAccent}
+              </span>
+            </h2>
+          </div>
         </Reveal>
 
-        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-          {visionContent.pillars.map((pillar) => (
-            <Reveal key={pillar.title} className="h-full">
-              <article className="h-full rounded-2xl border border-border bg-background/70 p-5">
-                <h3 className="text-sm font-bold tracking-wide text-primary uppercase">
-                  {pillar.title}
+        <div className="relative mx-auto max-w-5xl">
+          <div className="absolute top-[1.75rem] left-[10%] right-[10%] hidden h-px bg-border dark:bg-[#FF4D00]/30 md:block" />
+
+          <div className="grid grid-cols-2 gap-6 md:grid-cols-5 md:gap-4">
+            {visionContent.pillars.map((pillar) => (
+              <Reveal key={pillar.label} className="flex flex-col items-center text-center">
+                <div className="relative z-10 mb-4 flex h-14 w-14 items-center justify-center rounded-full border border-border bg-card text-muted-foreground dark:border-gray-700 dark:bg-[#0A0A0A] dark:text-gray-500 transition-all duration-300">
+                  <span className="text-xs">*</span>
+                </div>
+                <h3 className="mb-2 text-sm tracking-wider text-foreground dark:text-white uppercase transition-colors">
+                  {pillar.label}
                 </h3>
-                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                  {pillar.description}
+                <p className="whitespace-pre-line text-xs leading-relaxed text-muted-foreground dark:text-gray-500">
+                  {pillar.desc}
                 </p>
-              </article>
-            </Reveal>
-          ))}
+              </Reveal>
+            ))}
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -19,20 +19,24 @@ export function SiteFooter() {
         </h3>
 
         <ul className="flex items-center gap-4">
-          {socialLinks.map((item) => (
-            <li key={item.label}>
-              <a
-                href={item.href}
-                aria-label={item.label}
-                className="flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground transition-all duration-300 hover:border-[#FF4D00]/30 hover:text-[#FF4D00] dark:border-white/10 dark:text-gray-500"
-              >
-                {(() => {
-                  const Icon = iconMap[item.label as keyof typeof iconMap];
-                  return Icon ? <Icon size={16} /> : <span className="text-xs">*</span>;
-                })()}
-              </a>
-            </li>
-          ))}
+          {socialLinks.map((item) => {
+            const isExternal = /^https?:\/\//.test(item.href);
+            const Icon = iconMap[item.label as keyof typeof iconMap];
+
+            return (
+              <li key={item.label}>
+                <a
+                  href={item.href}
+                  aria-label={item.label}
+                  target={isExternal ? "_blank" : undefined}
+                  rel={isExternal ? "noopener noreferrer" : undefined}
+                  className="flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground transition-all duration-300 hover:border-[#FF4D00]/30 hover:text-[#FF4D00] dark:border-white/10 dark:text-gray-500"
+                >
+                  {Icon ? <Icon size={16} /> : <span className="text-xs">*</span>}
+                </a>
+              </li>
+            );
+          })}
         </ul>
 
         <p className="text-[10px] tracking-wider text-muted-foreground dark:text-gray-700">

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -1,3 +1,5 @@
+import { socialLinks } from "@/content/landing";
+
 export function SiteFooter() {
   const currentYear = new Date().getFullYear();
 
@@ -5,6 +7,17 @@ export function SiteFooter() {
     <footer className="border-t border-border py-10">
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-5 text-sm text-muted-foreground md:flex-row">
         <p className="font-semibold text-foreground">LIKELION CJU</p>
+
+        <ul className="flex items-center gap-4">
+          {socialLinks.map((item) => (
+            <li key={item.label}>
+              <a href={item.href} className="transition-colors hover:text-foreground">
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+
         <p>© {currentYear} LIKELION CJU. All rights reserved.</p>
       </div>
     </footer>

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -1,24 +1,43 @@
+import { Github, Globe, Instagram } from "lucide-react";
+
 import { socialLinks } from "@/content/landing";
 
 export function SiteFooter() {
   const currentYear = new Date().getFullYear();
 
+  const iconMap = {
+    Instagram,
+    Globe,
+    Github,
+  } as const;
+
   return (
-    <footer className="border-t border-border py-10">
-      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-5 text-sm text-muted-foreground md:flex-row">
-        <p className="font-semibold text-foreground">LIKELION CJU</p>
+    <footer className="w-full border-t border-border bg-background py-12 dark:border-white/5 dark:bg-[#050505]">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-8 px-6 text-sm text-muted-foreground md:flex-row md:px-12 lg:px-24">
+        <h3 className="text-sm tracking-[0.15em] text-foreground dark:text-white">
+          LIKELION <span className="text-[#FF4D00]">@ CJU</span>
+        </h3>
 
         <ul className="flex items-center gap-4">
           {socialLinks.map((item) => (
             <li key={item.label}>
-              <a href={item.href} className="transition-colors hover:text-foreground">
-                {item.label}
+              <a
+                href={item.href}
+                aria-label={item.label}
+                className="flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground transition-all duration-300 hover:border-[#FF4D00]/30 hover:text-[#FF4D00] dark:border-white/10 dark:text-gray-500"
+              >
+                {(() => {
+                  const Icon = iconMap[item.label as keyof typeof iconMap];
+                  return Icon ? <Icon size={16} /> : <span className="text-xs">*</span>;
+                })()}
               </a>
             </li>
           ))}
         </ul>
 
-        <p>© {currentYear} LIKELION CJU. All rights reserved.</p>
+        <p className="text-[10px] tracking-wider text-muted-foreground dark:text-gray-700">
+          © {currentYear} LIKELION CJU. All rights reserved.
+        </p>
       </div>
     </footer>
   );

--- a/src/content/landing.ts
+++ b/src/content/landing.ts
@@ -12,6 +12,39 @@ export type NavigationItem = {
   label: string;
 };
 
+type VisionPillar = {
+  title: string;
+  description: string;
+};
+
+type AboutStat = {
+  label: string;
+  value: string;
+};
+
+type TeamMember = {
+  role: string;
+  name: string;
+  part: string;
+};
+
+type CurriculumTrack = {
+  title: string;
+  description: string;
+  skills: string[];
+};
+
+type RoadmapItem = {
+  month: string;
+  title: string;
+  detail: string;
+};
+
+type SocialLink = {
+  label: string;
+  href: string;
+};
+
 export const navigationItems: NavigationItem[] = [
   { id: "intro", label: "Home" },
   { id: "vision", label: "Vision" },
@@ -23,3 +56,153 @@ export const navigationItems: NavigationItem[] = [
 ];
 
 export const sectionOrder: SectionId[] = navigationItems.map((item) => item.id);
+
+export const introContent = {
+  badge: "LIKELION 14TH GENERATION @ CJU",
+  titleTop: "BUILD YOUR",
+  titleAccent: "OWN UNIVERSE",
+  description:
+    "청주대학교 멋쟁이사자처럼 14기에서 실전 중심으로 기획-디자인-개발을 경험하고, 팀 프로젝트로 결과를 만드는 한 학기를 시작하세요.",
+  primaryCta: {
+    label: "14기 지원하러 가기",
+    href: "https://forms.gle/7M8Dfxv63tGuSEJ56",
+  },
+  secondaryCta: {
+    label: "커리큘럼 보기",
+    targetId: "curriculum" as SectionId,
+  },
+};
+
+export const visionContent: {
+  title: string;
+  subtitle: string;
+  pillars: VisionPillar[];
+} = {
+  title: "Our Vision",
+  subtitle: "아이디어를 실제 서비스로 만드는 인재를 육성합니다.",
+  pillars: [
+    {
+      title: "Problem Solving",
+      description: "문제를 정의하고 사용자 관점에서 해결책을 설계합니다.",
+    },
+    {
+      title: "Collaboration",
+      description: "기획-디자인-개발이 한 팀으로 협업하는 방식을 익힙니다.",
+    },
+    {
+      title: "Execution",
+      description: "짧은 주기로 만들고 검증하며 제품 완성도를 높입니다.",
+    },
+    {
+      title: "Growth",
+      description: "코드리뷰와 회고를 통해 개인과 팀의 성장을 추적합니다.",
+    },
+    {
+      title: "Impact",
+      description: "캠퍼스와 지역사회에 실제로 쓰이는 프로젝트를 만듭니다.",
+    },
+  ],
+};
+
+export const aboutContent: {
+  title: string;
+  description: string;
+  imageUrl: string;
+  stats: AboutStat[];
+} = {
+  title: "About LIKELION CJU",
+  description:
+    "청주대학교 멋쟁이사자처럼은 웹/앱 개발과 제품 사고를 중심으로 학습하는 학생 개발 커뮤니티입니다. 세션, 스터디, 프로젝트 데이를 통해 실무형 경험을 제공합니다.",
+  imageUrl:
+    "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1200&q=80",
+  stats: [
+    { label: "Active Members", value: "40+" },
+    { label: "Team Projects", value: "10+" },
+    { label: "Weekly Sessions", value: "12" },
+  ],
+};
+
+export const teamContent: {
+  title: string;
+  description: string;
+  members: TeamMember[];
+} = {
+  title: "Operating Team",
+  description: "14기의 운영을 함께 만드는 파트 리더와 운영진입니다.",
+  members: [
+    { role: "대표", name: "김은성", part: "Overall" },
+    { role: "운영", name: "김정우", part: "Operation" },
+    { role: "프론트", name: "박서연", part: "Frontend" },
+    { role: "백엔드", name: "이도현", part: "Backend" },
+    { role: "기획/디자인", name: "정유진", part: "Product" },
+    { role: "브랜딩", name: "최민지", part: "Brand" },
+  ],
+};
+
+export const curriculumContent: {
+  title: string;
+  tracks: CurriculumTrack[];
+} = {
+  title: "Curriculum",
+  tracks: [
+    {
+      title: "Web Foundation",
+      description: "HTML/CSS/JavaScript와 반응형 UI 기본기",
+      skills: ["Semantic HTML", "Tailwind", "Accessibility"],
+    },
+    {
+      title: "Frontend Development",
+      description: "React 기반 컴포넌트 설계와 상태 관리",
+      skills: ["React", "TypeScript", "State Flow"],
+    },
+    {
+      title: "Backend Development",
+      description: "API 설계, 데이터 모델링, 인증 기본",
+      skills: ["REST API", "DB Modeling", "Auth"],
+    },
+    {
+      title: "Product Thinking",
+      description: "문제 정의부터 검증까지 제품 중심 접근",
+      skills: ["User Story", "MVP", "Experiment"],
+    },
+    {
+      title: "Deployment",
+      description: "배포 파이프라인과 협업 워크플로우",
+      skills: ["CI/CD", "GitHub", "Monitoring"],
+    },
+    {
+      title: "Team Project",
+      description: "팀 단위로 서비스 기획/구현/발표",
+      skills: ["Sprint", "Code Review", "Demo Day"],
+    },
+  ],
+};
+
+export const roadmapContent: {
+  title: string;
+  items: RoadmapItem[];
+} = {
+  title: "Roadmap",
+  items: [
+    { month: "03", title: "Recruiting", detail: "지원서 접수 및 인터뷰" },
+    { month: "04", title: "Bootcamp", detail: "기초 세션 및 스터디 시작" },
+    { month: "05", title: "Build", detail: "트랙별 실습 및 미니 프로젝트" },
+    { month: "06", title: "Team Sprint", detail: "팀 프로젝트 스프린트" },
+    { month: "07", title: "Demo Day", detail: "최종 발표 및 회고" },
+  ],
+};
+
+export const applyContent = {
+  title: "Apply Now",
+  description:
+    "14기 모집은 제한 인원으로 진행됩니다. 아래 버튼에서 지원서를 제출해주세요.",
+  period: "모집 기간: 2026.03.04 - 2026.03.17",
+  ctaLabel: "14기 지원하러 가기",
+  ctaHref: "https://forms.gle/7M8Dfxv63tGuSEJ56",
+};
+
+export const socialLinks: SocialLink[] = [
+  { label: "Instagram", href: "#" },
+  { label: "GitHub", href: "#" },
+  { label: "Notion", href: "#" },
+];

--- a/src/content/landing.ts
+++ b/src/content/landing.ts
@@ -12,6 +12,102 @@ export type NavigationItem = {
   label: string;
 };
 
+type IntroContent = {
+  badge: string;
+  titleTop: string;
+  titleAccent: string;
+  descriptionTop: string;
+  descriptionStrong: string;
+  descriptionBottom: string;
+  backgroundImage: string;
+  primaryCta: {
+    label: string;
+    targetId: SectionId;
+  };
+};
+
+type VisionContent = {
+  label: string;
+  titleTop: string;
+  titleAccent: string;
+  pillars: Array<{
+    label: string;
+    desc: string;
+  }>;
+};
+
+type AboutContent = {
+  label: string;
+  titleTop: string;
+  titleAccent: string;
+  imageUrl: string;
+  imageAlt: string;
+  paragraphs: string[];
+  stats: Array<{
+    value: string;
+    label: string;
+  }>;
+};
+
+type TeamContent = {
+  label: string;
+  titleTop: string;
+  titleAccent: string;
+  subtitle: string;
+  leaders: Array<{
+    name: string;
+    role: string;
+    desc: string;
+  }>;
+  departments: Array<{
+    name: string;
+    members: Array<{
+      name: string;
+      desc: string;
+    }>;
+  }>;
+};
+
+type CurriculumContent = {
+  label: string;
+  titleTop: string;
+  titleAccent: string;
+  groups: Array<{
+    name: string;
+    subtitle: string;
+    items: Array<{
+      title: string;
+      desc: string;
+    }>;
+  }>;
+};
+
+type RoadmapContent = {
+  label: string;
+  titleTop: string;
+  titleAccent: string;
+  items: Array<{
+    period: string;
+    title: string;
+    color: string;
+    items: string[];
+  }>;
+};
+
+type ApplyContent = {
+  recruitLabel: string;
+  titleTop: string;
+  titleAccent: string;
+  ctaLabel: string;
+  ctaHref: string;
+  period: string;
+};
+
+type SocialLink = {
+  label: string;
+  href: string;
+};
+
 export const navigationItems: NavigationItem[] = [
   { id: "intro", label: "Home" },
   { id: "vision", label: "Vision" },
@@ -24,7 +120,7 @@ export const navigationItems: NavigationItem[] = [
 
 export const sectionOrder: SectionId[] = navigationItems.map((item) => item.id);
 
-export const introContent = {
+export const introContent: IntroContent = {
   badge: "LIKELION 14TH GENERATION @ CJU",
   titleTop: "BUILD YOUR",
   titleAccent: "OWN UNIVERSE",
@@ -39,7 +135,7 @@ export const introContent = {
   },
 };
 
-export const visionContent = {
+export const visionContent: VisionContent = {
   label: "Our Vision",
   titleTop: "함께 자라나는 즐거움,",
   titleAccent: "실패를 두려워하지 않는 도전",
@@ -52,12 +148,13 @@ export const visionContent = {
   ],
 };
 
-export const aboutContent = {
+export const aboutContent: AboutContent = {
   label: "About Us",
   titleTop: "청주대학교",
   titleAccent: "멋쟁이사자처럼",
   imageUrl:
     "https://images.unsplash.com/photo-1646579886741-12b59840c63f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx1bml2ZXJzaXR5JTIwc3R1ZGVudHMlMjB0ZWFtJTIwY29sbGFib3JhdGlvbiUyMHdvcmtzcGFjZXxlbnwxfHx8fDE3NzIyOTc0NTR8MA&ixlib=rb-4.1.0&q=80&w=1080",
+  imageAlt: "Team Collaboration",
   paragraphs: [
     "멋쟁이사자처럼 대학은 전국 70개 대학이 함께하는 AI/IT 연합 동아리입니다.",
     "IT와 AI에 대한 관심을 나누고, 함께 소통하며 성장합니다. 코딩이 처음인 분도, 이미 경험이 있는 분도 모두 환영합니다. 우리는 함께 배우고, 함께 만들고, 함께 성장하는 커뮤니티입니다.",
@@ -71,7 +168,7 @@ export const aboutContent = {
   ],
 };
 
-export const teamContent = {
+export const teamContent: TeamContent = {
   label: "Operating Staff",
   titleTop: "14TH",
   titleAccent: "CREW",
@@ -105,7 +202,7 @@ export const teamContent = {
   ],
 };
 
-export const curriculumContent = {
+export const curriculumContent: CurriculumContent = {
   label: "Original Class",
   titleTop: "CJU",
   titleAccent: "CURRICULUM",
@@ -155,7 +252,7 @@ export const curriculumContent = {
   ],
 };
 
-export const roadmapContent = {
+export const roadmapContent: RoadmapContent = {
   label: "Annual Schedule",
   titleTop: "14TH",
   titleAccent: "ROADMAP",
@@ -201,7 +298,7 @@ export const roadmapContent = {
   ],
 };
 
-export const applyContent = {
+export const applyContent: ApplyContent = {
   recruitLabel: "Now Recruiting",
   titleTop: "JOIN",
   titleAccent: "US",
@@ -210,7 +307,7 @@ export const applyContent = {
   period: "모집 기간: 2026.03.02 ~ 2026.03.09",
 };
 
-export const socialLinks = [
+export const socialLinks: SocialLink[] = [
   { label: "Instagram", href: "#" },
   { label: "Globe", href: "#" },
   { label: "Github", href: "#" },

--- a/src/content/landing.ts
+++ b/src/content/landing.ts
@@ -12,39 +12,6 @@ export type NavigationItem = {
   label: string;
 };
 
-type VisionPillar = {
-  title: string;
-  description: string;
-};
-
-type AboutStat = {
-  label: string;
-  value: string;
-};
-
-type TeamMember = {
-  role: string;
-  name: string;
-  part: string;
-};
-
-type CurriculumTrack = {
-  title: string;
-  description: string;
-  skills: string[];
-};
-
-type RoadmapItem = {
-  month: string;
-  title: string;
-  detail: string;
-};
-
-type SocialLink = {
-  label: string;
-  href: string;
-};
-
 export const navigationItems: NavigationItem[] = [
   { id: "intro", label: "Home" },
   { id: "vision", label: "Vision" },
@@ -61,148 +28,190 @@ export const introContent = {
   badge: "LIKELION 14TH GENERATION @ CJU",
   titleTop: "BUILD YOUR",
   titleAccent: "OWN UNIVERSE",
-  description:
-    "청주대학교 멋쟁이사자처럼 14기에서 실전 중심으로 기획-디자인-개발을 경험하고, 팀 프로젝트로 결과를 만드는 한 학기를 시작하세요.",
+  descriptionTop: "가능성을 현실로, 13기를 넘어 14기로.",
+  descriptionStrong: "청주대학교 멋쟁이사자처럼",
+  descriptionBottom: "이 14기 아기사자를 기다립니다.",
+  backgroundImage:
+    "https://images.unsplash.com/photo-1738255654134-1877cb984a8f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkYXJrJTIwY29kaW5nJTIwbGFwdG9wJTIwc2NyZWVuJTIwcHJvZ3JhbW1pbmd8ZW58MXx8fHwxNzcyMjk3NDU0fDA&ixlib=rb-4.1.0&q=80&w=1080",
   primaryCta: {
-    label: "14기 지원하러 가기",
-    href: "https://forms.gle/7M8Dfxv63tGuSEJ56",
-  },
-  secondaryCta: {
-    label: "커리큘럼 보기",
-    targetId: "curriculum" as SectionId,
+    label: "Apply Now",
+    targetId: "apply" as SectionId,
   },
 };
 
-export const visionContent: {
-  title: string;
-  subtitle: string;
-  pillars: VisionPillar[];
-} = {
-  title: "Our Vision",
-  subtitle: "아이디어를 실제 서비스로 만드는 인재를 육성합니다.",
+export const visionContent = {
+  label: "Our Vision",
+  titleTop: "함께 자라나는 즐거움,",
+  titleAccent: "실패를 두려워하지 않는 도전",
   pillars: [
-    {
-      title: "Problem Solving",
-      description: "문제를 정의하고 사용자 관점에서 해결책을 설계합니다.",
-    },
-    {
-      title: "Collaboration",
-      description: "기획-디자인-개발이 한 팀으로 협업하는 방식을 익힙니다.",
-    },
-    {
-      title: "Execution",
-      description: "짧은 주기로 만들고 검증하며 제품 완성도를 높입니다.",
-    },
-    {
-      title: "Growth",
-      description: "코드리뷰와 회고를 통해 개인과 팀의 성장을 추적합니다.",
-    },
-    {
-      title: "Impact",
-      description: "캠퍼스와 지역사회에 실제로 쓰이는 프로젝트를 만듭니다.",
-    },
+    { label: "Discover", desc: "나만의 가능성을\n발견하세요" },
+    { label: "Learn", desc: "체계적인 커리큘럼으로\n성장하세요" },
+    { label: "Share", desc: "지식과 경험을\n공유하세요" },
+    { label: "Build", desc: "아이디어를\n현실로 만드세요" },
+    { label: "Impact", desc: "세상을 바꾸는\n임팩트를 만드세요" },
   ],
 };
 
-export const aboutContent: {
-  title: string;
-  description: string;
-  imageUrl: string;
-  stats: AboutStat[];
-} = {
-  title: "About LIKELION CJU",
-  description:
-    "청주대학교 멋쟁이사자처럼은 웹/앱 개발과 제품 사고를 중심으로 학습하는 학생 개발 커뮤니티입니다. 세션, 스터디, 프로젝트 데이를 통해 실무형 경험을 제공합니다.",
+export const aboutContent = {
+  label: "About Us",
+  titleTop: "청주대학교",
+  titleAccent: "멋쟁이사자처럼",
   imageUrl:
-    "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1200&q=80",
+    "https://images.unsplash.com/photo-1646579886741-12b59840c63f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx1bml2ZXJzaXR5JTIwc3R1ZGVudHMlMjB0ZWFtJTIwY29sbGFib3JhdGlvbiUyMHdvcmtzcGFjZXxlbnwxfHx8fDE3NzIyOTc0NTR8MA&ixlib=rb-4.1.0&q=80&w=1080",
+  paragraphs: [
+    "멋쟁이사자처럼 대학은 전국 70개 대학이 함께하는 AI/IT 연합 동아리입니다.",
+    "IT와 AI에 대한 관심을 나누고, 함께 소통하며 성장합니다. 코딩이 처음인 분도, 이미 경험이 있는 분도 모두 환영합니다. 우리는 함께 배우고, 함께 만들고, 함께 성장하는 커뮤니티입니다.",
+    "14기에서는 프론트엔드, 백엔드, 기획/디자인 트랙으로 나뉘어 체계적인 스터디를 진행하며, 중앙 해커톤, 아이디어톤, 연합 해커톤 등 다양한 활동에 참여합니다.",
+  ],
   stats: [
-    { label: "Active Members", value: "40+" },
-    { label: "Team Projects", value: "10+" },
-    { label: "Weekly Sessions", value: "12" },
+    { value: "70+", label: "전국 참여 대학" },
+    { value: "5,000+", label: "전국 활동 멤버" },
+    { value: "13", label: "역대 기수" },
+    { value: "∞", label: "무한한 가능성" },
   ],
 };
 
-export const teamContent: {
-  title: string;
-  description: string;
-  members: TeamMember[];
-} = {
-  title: "Operating Team",
-  description: "14기의 운영을 함께 만드는 파트 리더와 운영진입니다.",
-  members: [
-    { role: "대표", name: "김은성", part: "Overall" },
-    { role: "운영", name: "김정우", part: "Operation" },
-    { role: "프론트", name: "박서연", part: "Frontend" },
-    { role: "백엔드", name: "이도현", part: "Backend" },
-    { role: "기획/디자인", name: "정유진", part: "Product" },
-    { role: "브랜딩", name: "최민지", part: "Brand" },
+export const teamContent = {
+  label: "Operating Staff",
+  titleTop: "14TH",
+  titleAccent: "CREW",
+  subtitle: "청주대학교 멋쟁이사자처럼 14기를 이끌어갈 운영진을 소개합니다.",
+  leaders: [
+    { name: "김재영", role: "대표", desc: "14기 방향성 제시 및 전체 운영 총괄" },
+    { name: "문태희", role: "부대표", desc: "각 부서 활동 관리 및 내부 운영 지원" },
   ],
-};
-
-export const curriculumContent: {
-  title: string;
-  tracks: CurriculumTrack[];
-} = {
-  title: "Curriculum",
-  tracks: [
+  departments: [
     {
-      title: "Web Foundation",
-      description: "HTML/CSS/JavaScript와 반응형 UI 기본기",
-      skills: ["Semantic HTML", "Tailwind", "Accessibility"],
+      name: "학술부",
+      members: [
+        { name: "조완수", desc: "정기 세션 및 커리큘럼 로드맵 관리·아기사자 학습 자료 검토" },
+        { name: "고성노", desc: "정기 세션 및 공식 GitHub 운영, 과제 관리·기술 멘토링 총괄" },
+      ],
     },
     {
-      title: "Frontend Development",
-      description: "React 기반 컴포넌트 설계와 상태 관리",
-      skills: ["React", "TypeScript", "State Flow"],
+      name: "기획부",
+      members: [
+        { name: "박세령", desc: "동아리 행사 및 프로젝트 전략 기획•운영 총괄" },
+        { name: "홍지우", desc: "동아리 핵심 행사 기획 총괄 및 프로젝트 기획 리드" },
+      ],
     },
     {
-      title: "Backend Development",
-      description: "API 설계, 데이터 모델링, 인증 기본",
-      skills: ["REST API", "DB Modeling", "Auth"],
-    },
-    {
-      title: "Product Thinking",
-      description: "문제 정의부터 검증까지 제품 중심 접근",
-      skills: ["User Story", "MVP", "Experiment"],
-    },
-    {
-      title: "Deployment",
-      description: "배포 파이프라인과 협업 워크플로우",
-      skills: ["CI/CD", "GitHub", "Monitoring"],
-    },
-    {
-      title: "Team Project",
-      description: "팀 단위로 서비스 기획/구현/발표",
-      skills: ["Sprint", "Code Review", "Demo Day"],
+      name: "홍보부",
+      members: [
+        { name: "서우진", desc: "홍보 콘텐츠 기획 및 제작 총괄" },
+        { name: "전예원", desc: "홍보 콘텐츠 기획 및 SNS 채널 운영" },
+      ],
     },
   ],
 };
 
-export const roadmapContent: {
-  title: string;
-  items: RoadmapItem[];
-} = {
-  title: "Roadmap",
+export const curriculumContent = {
+  label: "Original Class",
+  titleTop: "CJU",
+  titleAccent: "CURRICULUM",
+  groups: [
+    {
+      name: "프론트엔드",
+      subtitle: "Frontend Track",
+      items: [
+        {
+          title: "HTML/CSS & JS",
+          desc: "웹의 기초가 되는 마크업 언어와 스타일링, 그리고 자바스크립트 핵심 개념을 학습합니다.",
+        },
+        {
+          title: "React & Frontend",
+          desc: "컴포넌트 기반 UI 개발, 상태 관리, SPA 구축 등 현대적인 프론트엔드 기술을 익힙니다.",
+        },
+      ],
+    },
+    {
+      name: "백엔드",
+      subtitle: "Backend Track",
+      items: [
+        {
+          title: "Python & Django",
+          desc: "파이썬 기초부터 장고 프레임워크를 활용한 백엔드 서버 구축 과정을 다룹니다.",
+        },
+        {
+          title: "Database & API",
+          desc: "데이터 모델링, RESTful API 설계 및 연동을 통해 데이터 흐름을 이해합니다.",
+        },
+      ],
+    },
+    {
+      name: "기획/디자인",
+      subtitle: "Product Design Track",
+      items: [
+        {
+          title: "UI/UX Design",
+          desc: "사용자 경험을 고려한 인터페이스 설계와 Figma를 활용한 프로토타이핑을 진행합니다.",
+        },
+        {
+          title: "AI Convergence",
+          desc: "ChatGPT API 등 생성형 AI 기술을 프로젝트에 접목하여 혁신적인 서비스를 개발합니다.",
+        },
+      ],
+    },
+  ],
+};
+
+export const roadmapContent = {
+  label: "Annual Schedule",
+  titleTop: "14TH",
+  titleAccent: "ROADMAP",
   items: [
-    { month: "03", title: "Recruiting", detail: "지원서 접수 및 인터뷰" },
-    { month: "04", title: "Bootcamp", detail: "기초 세션 및 스터디 시작" },
-    { month: "05", title: "Build", detail: "트랙별 실습 및 미니 프로젝트" },
-    { month: "06", title: "Team Sprint", detail: "팀 프로젝트 스프린트" },
-    { month: "07", title: "Demo Day", detail: "최종 발표 및 회고" },
+    {
+      period: "2월 ~ 3월",
+      title: "The Beginning",
+      color: "#4ADE80",
+      items: [
+        "14기 아기사자 모집 및 선발",
+        "오리엔테이션 (OT) & 리더십 트레이닝",
+        "PBL 스터디 자료 배포",
+      ],
+    },
+    {
+      period: "3월 ~ 6월",
+      title: "Growth",
+      color: "#60A5FA",
+      items: [
+        "학교별 트랙 스터디 진행",
+        "Front-end / Back-end / 기획 / 디자인",
+        "기초 역량 강화 및 미니 프로젝트",
+      ],
+    },
+    {
+      period: "5월",
+      title: "Ideathon",
+      color: "#FBBF24",
+      items: ["무박 2일 아이디어 해커톤", "팀 빌딩 및 아이디어 구체화", "현직자 멘토링"],
+    },
+    {
+      period: "7월 ~ 8월",
+      title: "Hackathon",
+      color: "#FF4D00",
+      items: ["중앙 해커톤", "여름방학 집중 개발 기간", "실전 서비스 배포 경험"],
+    },
+    {
+      period: "9월 ~ 12월",
+      title: "Expansion",
+      color: "#A78BFA",
+      items: ["연합 해커톤 (충청권)", "기업 연계 프로젝트", "최종 성과 공유회 (Demoday)"],
+    },
   ],
 };
 
 export const applyContent = {
-  title: "Apply Now",
-  description:
-    "14기 모집은 제한 인원으로 진행됩니다. 아래 버튼에서 지원서를 제출해주세요.",
-  period: "모집 기간: 2026.03.04 - 2026.03.17",
+  recruitLabel: "Now Recruiting",
+  titleTop: "JOIN",
+  titleAccent: "US",
   ctaLabel: "14기 지원하러 가기",
   ctaHref: "https://forms.gle/7M8Dfxv63tGuSEJ56",
+  period: "모집 기간: 2026.03.02 ~ 2026.03.09",
 };
 
-export const socialLinks: SocialLink[] = [
+export const socialLinks = [
   { label: "Instagram", href: "#" },
-  { label: "GitHub", href: "#" },
-  { label: "Notion", href: "#" },
+  { label: "Globe", href: "#" },
+  { label: "Github", href: "#" },
 ];


### PR DESCRIPTION
## 변경 사항
- 랜딩 페이지 섹션(`intro`, `vision`, `about`, `team`, `curriculum`, `roadmap`, `apply`)의 플레이스홀더를 실제 콘텐츠 기반 UI 블록으로 교체했습니다.
- `src/content/landing.ts`를 확장해 섹션별 카피/카드/통계/타임라인/CTA 데이터를 중앙화했습니다.
- `SiteFooter`에 소셜 링크 배열(`socialLinks`) 기반 렌더링을 추가했습니다.
- 섹션 전반에 `Reveal` 기반 진입 애니메이션과 토큰 기반 스타일(`bg-background`, `bg-card`, `border-border`, `text-muted-foreground`)을 적용했습니다.

## 목적
- Stage 3 목표인 “섹션 콘텐츠 + 콘텐츠 모델” 구현을 완료해, 다음 Stage 4(E2E 테스트 자동화)를 진행할 수 있는 상태를 만듭니다.

## 검증 방법
- `bun run lint`
- `bun run build`