### PR TITLE
test(e2e): 랜딩 페이지 내비게이션 검증 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,11 @@ out
 .nuxt
 dist
 
+# Playwright
+playwright-report/
+test-results/
+blob-report/
+
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.56.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -233,6 +234,8 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -972,6 +975,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
@@ -1245,6 +1252,8 @@
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,13 +1,12 @@
 import { expect, test } from "@playwright/test";
 
 const SECTION_IDS = ["intro", "vision", "about", "team", "curriculum", "roadmap", "apply"];
+const HEADER_HEIGHT = 64;
 
 test("sections exist", async ({ page }) => {
   await page.goto("/");
 
-  for (const id of SECTION_IDS) {
-    await expect(page.locator(`#${id}`)).toBeVisible();
-  }
+  await Promise.all(SECTION_IDS.map((id) => expect(page.locator(`#${id}`)).toBeVisible()));
 });
 
 test("header anchor offset keeps section visible under fixed header", async ({ page }) => {
@@ -15,21 +14,21 @@ test("header anchor offset keeps section visible under fixed header", async ({ p
 
   await expect.poll(async () => {
     return page.locator("#about").evaluate((el) => el.getBoundingClientRect().top);
-  }).toBeGreaterThanOrEqual(64);
+  }).toBeGreaterThanOrEqual(HEADER_HEIGHT);
 });
 
 test("scrollspy sets aria-current on the active roadmap nav link", async ({ page }) => {
   await page.goto("/");
 
-  await page.evaluate(() => {
+  await page.evaluate((headerHeight) => {
     const roadmap = document.getElementById("roadmap");
     if (!roadmap) {
       return;
     }
 
-    const y = roadmap.getBoundingClientRect().top + window.scrollY - 64;
+    const y = roadmap.getBoundingClientRect().top + window.scrollY - headerHeight;
     window.scrollTo({ top: Math.max(0, y), behavior: "auto" });
-  });
+  }, HEADER_HEIGHT);
 
   const roadmapNavLink = page.locator('nav[aria-label="Primary"] a[href="#roadmap"]');
   await expect.poll(async () => roadmapNavLink.getAttribute("aria-current")).toBe("true");
@@ -45,11 +44,19 @@ test("mobile menu keeps focus trapped and closes on Escape", async ({ page }) =>
   await toggle.click();
   await expect(panel).toBeVisible();
 
-  for (let i = 0; i < 10; i += 1) {
-    await page.keyboard.press("Tab");
-    const isFocusInsidePanel = await panel.evaluate((el) => el.contains(document.activeElement));
-    expect(isFocusInsidePanel).toBe(true);
-  }
+  const focusables = panel.locator("a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])");
+  const focusableCount = await focusables.count();
+  expect(focusableCount).toBeGreaterThan(0);
+
+  const firstFocusable = focusables.first();
+  const lastFocusable = focusables.nth(focusableCount - 1);
+
+  await lastFocusable.focus();
+  await page.keyboard.press("Tab");
+  await expect(firstFocusable).toBeFocused();
+
+  await page.keyboard.press("Shift+Tab");
+  await expect(lastFocusable).toBeFocused();
 
   await page.keyboard.press("Escape");
   await expect(panel).toBeHidden();

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "@playwright/test";
+
+const SECTION_IDS = ["intro", "vision", "about", "team", "curriculum", "roadmap", "apply"];
+
+test("sections exist", async ({ page }) => {
+  await page.goto("/");
+
+  for (const id of SECTION_IDS) {
+    await expect(page.locator(`#${id}`)).toBeVisible();
+  }
+});
+
+test("header anchor offset keeps section visible under fixed header", async ({ page }) => {
+  await page.goto("/#about");
+
+  await expect.poll(async () => {
+    return page.locator("#about").evaluate((el) => el.getBoundingClientRect().top);
+  }).toBeGreaterThanOrEqual(64);
+});
+
+test("scrollspy sets aria-current on the active roadmap nav link", async ({ page }) => {
+  await page.goto("/");
+
+  await page.evaluate(() => {
+    const roadmap = document.getElementById("roadmap");
+    if (!roadmap) {
+      return;
+    }
+
+    const y = roadmap.getBoundingClientRect().top + window.scrollY - 64;
+    window.scrollTo({ top: Math.max(0, y), behavior: "auto" });
+  });
+
+  const roadmapNavLink = page.locator('nav[aria-label="Primary"] a[href="#roadmap"]');
+  await expect.poll(async () => roadmapNavLink.getAttribute("aria-current")).toBe("true");
+});
+
+test("mobile menu keeps focus trapped and closes on Escape", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  const toggle = page.getByTestId("mobile-nav-toggle");
+  const panel = page.getByTestId("mobile-nav-panel");
+
+  await toggle.click();
+  await expect(panel).toBeVisible();
+
+  for (let i = 0; i < 10; i += 1) {
+    await page.keyboard.press("Tab");
+    const isFocusInsidePanel = await panel.evaluate((el) => el.contains(document.activeElement));
+    expect(isFocusInsidePanel).toBe(true);
+  }
+
+  await page.keyboard.press("Escape");
+  await expect(panel).toBeHidden();
+  await expect(toggle).toBeFocused();
+});
+
+test.describe("reduced motion", () => {
+  test("nav click uses non-animated scrolling and updates hash", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+
+    await page.addInitScript(() => {
+      const original = Element.prototype.scrollIntoView;
+      const win = window as typeof window & { __scrollBehaviors?: string[] };
+
+      win.__scrollBehaviors = [];
+
+      Element.prototype.scrollIntoView = function scrollIntoViewPatched(arg?: ScrollIntoViewOptions | boolean) {
+        if (typeof arg === "object" && arg !== null) {
+          const behavior = arg.behavior ?? "auto";
+          win.__scrollBehaviors?.push(behavior);
+        }
+
+        if (typeof arg === "boolean" || arg === undefined) {
+          win.__scrollBehaviors?.push("auto");
+        }
+
+        return original.call(this, arg as never);
+      };
+    });
+
+    await page.goto("/");
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: "auto" }));
+
+    await page.locator('nav[aria-label="Primary"] a[href="#roadmap"]').click();
+
+    await expect(page).toHaveURL(/#roadmap$/);
+
+    const lastScrollBehavior = await page.evaluate(() => {
+      const behaviors = (window as Window & { __scrollBehaviors?: string[] }).__scrollBehaviors ?? [];
+      return {
+        last: behaviors[behaviors.length - 1] ?? null,
+        hasAuto: behaviors.includes("auto"),
+      };
+    });
+    expect(lastScrollBehavior.hasAuto).toBe(true);
+
+    const immediateScrollY = await page.evaluate(() => window.scrollY);
+    expect(immediateScrollY).toBeGreaterThan(0);
+  });
+});
+
+test("theme toggle updates html.dark and localStorage.theme", async ({ page }) => {
+  await page.goto("/");
+
+  const before = await page.evaluate(() => document.documentElement.classList.contains("dark"));
+
+  await page.getByTestId("theme-toggle").click();
+
+  const after = await page.evaluate(() => document.documentElement.classList.contains("dark"));
+  expect(after).toBe(!before);
+
+  const storedTheme = await page.evaluate(() => localStorage.getItem("theme"));
+  expect(storedTheme).toBe(after ? "dark" : "light");
+});
+
+test("theme bootstrap applies stored dark mode on first render", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("theme", "dark");
+  });
+
+  await page.goto("/");
+
+  await expect.poll(async () => {
+    return page.evaluate(() => document.documentElement.classList.contains("dark"));
+  }).toBe(true);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
@@ -27,6 +28,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@playwright/test": "^1.56.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:5173/",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: "bun run dev -- --host 127.0.0.1 --port 5173",
+    url: "http://127.0.0.1:5173/",
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## 작업 내용
- 랜딩 페이지 회귀 검증을 위한 Playwright E2E 테스트 인프라를 추가했습니다.
- `playwright.config.ts`를 추가하고, 고정 로컬 URL 및 webServer 자동 실행 설정을 구성했습니다.
- `e2e/landing.spec.ts`에 아래 시나리오를 추가했습니다.
  - 섹션 존재 여부
  - 헤더 앵커 오프셋
  - 스크롤스파이 활성 상태(`aria-current`)
  - 모바일 메뉴 접근성(포커스 트랩/ESC/포커스 복귀)
  - reduced-motion 동작
  - 테마 토글 저장/복원
- `test:e2e` 스크립트 및 Playwright 산출물 ignore 설정을 추가했습니다.

## 작업 이유
- Stage 4 품질 게이트를 자동화하여, 핵심 내비게이션/접근성/테마 동작을 머지 전에 일관되게 검증하기 위함입니다.

## 검증 방법
- bun install --frozen-lockfile
- bun run build
- bunx playwright install --with-deps
- bun run test:e2e