### PR TITLE
feat(landing): cup to lion 커리큘럼 섹션 추가

### DIFF
--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const SECTION_IDS = ["intro", "vision", "about", "team", "curriculum", "roadmap", "apply"];
+const SECTION_IDS = ["intro", "vision", "about", "team", "curriculum", "cup-to-lion", "roadmap", "apply"];
 const HEADER_HEIGHT = 64;
 
 test("sections exist", async ({ page }) => {

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -3,7 +3,7 @@ import { aboutContent } from "@/content/landing";
 
 export function AboutSection() {
   return (
-    <section id="about" className="scroll-mt-16 py-24 md:py-32" >
+    <section id="about" className="pb-24 md:pb-32" >
       <div className="relative mb-16 h-[300px] w-full overflow-hidden md:h-[400px]">
         <img src={aboutContent.imageUrl} alt={aboutContent.imageAlt} className="h-full w-full object-cover" />
         <div className="absolute inset-0 bg-gradient-to-t from-white via-white/70 to-transparent dark:from-[#050505] dark:via-[#050505]/70" />

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -13,10 +13,10 @@ export function AboutSection() {
           <span className="mb-3 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
             {aboutContent.label}
           </span>
-          <h2 className="text-3xl text-foreground dark:text-white md:text-5xl">
+          <h2 className="text-3xl font-bold text-foreground dark:text-white md:text-5xl">
             {aboutContent.titleTop}
             <br />
-            <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+            <span className="text-[#FF4D00]">
               {aboutContent.titleAccent}
             </span>
           </h2>

--- a/src/components/sections/ApplySection.tsx
+++ b/src/components/sections/ApplySection.tsx
@@ -20,8 +20,8 @@ export function ApplySection() {
             <Sparkles className="h-4 w-4" />
           </div>
 
-          <h2 className="mb-4 text-4xl tracking-tight text-foreground dark:text-white sm:text-5xl md:text-7xl">
-            {applyContent.titleTop} <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">{applyContent.titleAccent}</span>
+          <h2 className="mb-4 text-4xl font-bold tracking-tight text-foreground dark:text-white sm:text-5xl md:text-7xl">
+            {applyContent.titleTop} <span className="text-[#FF4D00]">{applyContent.titleAccent}</span>
           </h2>
 
           <a

--- a/src/components/sections/ApplySection.tsx
+++ b/src/components/sections/ApplySection.tsx
@@ -6,7 +6,7 @@ export function ApplySection() {
   return (
     <section
       id="apply"
-      className="relative flex min-h-[80vh] scroll-mt-16 flex-col items-center justify-center px-5 py-32 text-center md:py-40"
+      className="relative flex min-h-[80vh] flex-col items-center justify-center px-5 py-32 text-center md:py-40"
     >
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#FF4D00]/5 blur-[120px]" />

--- a/src/components/sections/ApplySection.tsx
+++ b/src/components/sections/ApplySection.tsx
@@ -6,7 +6,7 @@ export function ApplySection() {
   return (
     <section
       id="apply"
-      className="relative flex min-h-[80vh] flex-col items-center justify-center scroll-mt-16 px-5 py-32 text-center md:py-40"
+      className="relative flex min-h-[80vh] scroll-mt-16 flex-col items-center justify-center px-5 py-32 text-center md:py-40"
     >
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#FF4D00]/5 blur-[120px]" />

--- a/src/components/sections/CupToLionSection.tsx
+++ b/src/components/sections/CupToLionSection.tsx
@@ -12,7 +12,7 @@ const STEP_ICONS: Record<string, LucideIcon> = {
 
 export function CupToLionSection() {
   return (
-    <section id="cup-to-lion" className="min-h-screen scroll-mt-16 bg-background px-5 py-24 md:py-32">
+    <section id="cup-to-lion" className="min-h-screen bg-background px-5 py-24 md:py-32">
       <div className="mx-auto max-w-6xl">
         <Reveal>
           <div className="mx-auto mb-16 max-w-3xl text-center">

--- a/src/components/sections/CupToLionSection.tsx
+++ b/src/components/sections/CupToLionSection.tsx
@@ -1,0 +1,56 @@
+import { Search, Shuffle, Package } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { Reveal } from "@/components/motion/Reveal";
+import { cupToLionContent } from "@/content/landing";
+
+const STEP_ICONS: Record<string, LucideIcon> = {
+  "Step 1": Search,
+  "Step 2": Shuffle,
+  "Step 3": Package,
+};
+
+export function CupToLionSection() {
+  return (
+    <section id="cup-to-lion" className="min-h-screen scroll-mt-16 bg-background dark:bg-[#0A0A0A] px-5 py-24 md:py-32">
+      <div className="mx-auto max-w-6xl">
+        <Reveal>
+          <div className="mx-auto mb-16 max-w-3xl text-center">
+            <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">{cupToLionContent.label}</span>
+            <h2 className="text-3xl font-bold text-foreground dark:text-white md:text-5xl">
+              {cupToLionContent.titleTop}{" "}
+              <span className="text-[#FF4D00]">{cupToLionContent.titleAccent}</span>
+            </h2>
+            <p className="mx-auto mt-6 max-w-2xl text-sm leading-relaxed text-muted-foreground dark:text-gray-400 md:text-base">
+              {cupToLionContent.descriptionTop}
+            </p>
+            <p className="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground dark:text-gray-500 md:text-base">
+              {cupToLionContent.descriptionBottom}
+            </p>
+          </div>
+        </Reveal>
+
+        <div className="relative mx-auto grid max-w-6xl md:grid-cols-3">
+          <div className="pointer-events-none absolute top-14 left-[16.66%] hidden h-[1px] w-[66.66%] bg-border dark:bg-white/10 md:block" />
+
+          {cupToLionContent.steps.map((item) => {
+            const Icon = STEP_ICONS[item.step] || Package;
+
+            return (
+              <Reveal key={item.step}>
+                <article className="relative bg-transparent p-6 text-center">
+                  <div className="relative z-10 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border-2 bg-background dark:bg-[#0A0A0A]" style={{ borderColor: item.color, color: item.color }}>
+                    <Icon className="h-7 w-7" />
+                  </div>
+                  <p className="mb-2 text-sm font-semibold tracking-[0.2em] uppercase" style={{ color: item.color }}>{item.step}</p>
+                  <h3 className="mb-3 text-lg font-bold text-foreground dark:text-white md:text-xl">{item.title}</h3>
+                  <p className="text-sm font-medium leading-relaxed text-muted-foreground dark:text-gray-500">{item.desc}</p>
+                </article>
+              </Reveal>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/CupToLionSection.tsx
+++ b/src/components/sections/CupToLionSection.tsx
@@ -5,21 +5,21 @@ import { Reveal } from "@/components/motion/Reveal";
 import { cupToLionContent } from "@/content/landing";
 
 const STEP_ICONS: Record<string, LucideIcon> = {
-  "Step 1": Search,
-  "Step 2": Shuffle,
-  "Step 3": Package,
+  search: Search,
+  shuffle: Shuffle,
+  package: Package,
 };
 
 export function CupToLionSection() {
   return (
-    <section id="cup-to-lion" className="min-h-screen scroll-mt-16 bg-background dark:bg-[#0A0A0A] px-5 py-24 md:py-32">
+    <section id="cup-to-lion" className="min-h-screen scroll-mt-16 bg-background px-5 py-24 md:py-32">
       <div className="mx-auto max-w-6xl">
         <Reveal>
           <div className="mx-auto mb-16 max-w-3xl text-center">
-            <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">{cupToLionContent.label}</span>
+            <span className="mb-4 block text-xs tracking-[0.3em] text-primary uppercase">{cupToLionContent.label}</span>
             <h2 className="text-3xl font-bold text-foreground dark:text-white md:text-5xl">
               {cupToLionContent.titleTop}{" "}
-              <span className="text-[#FF4D00]">{cupToLionContent.titleAccent}</span>
+              <span className="text-primary">{cupToLionContent.titleAccent}</span>
             </h2>
             <p className="mx-auto mt-6 max-w-2xl text-sm leading-relaxed text-muted-foreground dark:text-gray-400 md:text-base">
               {cupToLionContent.descriptionTop}
@@ -34,12 +34,12 @@ export function CupToLionSection() {
           <div className="pointer-events-none absolute top-14 left-[16.66%] hidden h-[1px] w-[66.66%] bg-border dark:bg-white/10 md:block" />
 
           {cupToLionContent.steps.map((item) => {
-            const Icon = STEP_ICONS[item.step] || Package;
+            const Icon = STEP_ICONS[item.icon] || Package;
 
             return (
               <Reveal key={item.step}>
                 <article className="relative bg-transparent p-6 text-center">
-                  <div className="relative z-10 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border-2 bg-background dark:bg-[#0A0A0A]" style={{ borderColor: item.color, color: item.color }}>
+                  <div className="relative z-10 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border-2 bg-card" style={{ borderColor: item.color, color: item.color }}>
                     <Icon className="h-7 w-7" />
                   </div>
                   <p className="mb-2 text-sm font-semibold tracking-[0.2em] uppercase" style={{ color: item.color }}>{item.step}</p>

--- a/src/components/sections/CurriculumSection.tsx
+++ b/src/components/sections/CurriculumSection.tsx
@@ -21,9 +21,9 @@ export function CurriculumSection() {
             <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
               {curriculumContent.label}
             </span>
-            <h2 className="text-3xl text-foreground dark:text-white md:text-5xl">
+            <h2 className="text-3xl font-bold text-foreground dark:text-white md:text-5xl">
               {curriculumContent.titleTop}{" "}
-              <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+              <span className="text-[#FF4D00]">
                 {curriculumContent.titleAccent}
               </span>
             </h2>

--- a/src/components/sections/CurriculumSection.tsx
+++ b/src/components/sections/CurriculumSection.tsx
@@ -14,7 +14,7 @@ const TRACK_ICONS: Record<string, LucideIcon> = {
 
 export function CurriculumSection() {
   return (
-    <section id="curriculum" className="min-h-screen scroll-mt-16 bg-background dark:bg-[#0A0A0A] px-5 py-24 md:py-32">
+    <section id="curriculum" className="min-h-screen bg-background dark:bg-[#0A0A0A] px-5 py-24 md:py-32">
       <div className="mx-auto max-w-6xl">
         <Reveal>
           <div className="mb-16 text-center">

--- a/src/components/sections/IntroSection.tsx
+++ b/src/components/sections/IntroSection.tsx
@@ -6,7 +6,7 @@ export function IntroSection() {
   return (
     <section
       id="intro"
-      className="relative flex min-h-screen items-center justify-center scroll-mt-16 overflow-hidden bg-background"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background"
     >
       <div className="absolute inset-0 z-0">
         <img

--- a/src/components/sections/IntroSection.tsx
+++ b/src/components/sections/IntroSection.tsx
@@ -31,10 +31,10 @@ export function IntroSection() {
             {introContent.badge}
           </span>
 
-          <h1 className="mb-8 text-5xl tracking-tight text-foreground dark:text-white sm:text-6xl md:text-8xl lg:text-9xl">
+          <h1 className="mb-8 text-5xl font-bold tracking-tight text-foreground dark:text-white sm:text-6xl md:text-8xl lg:text-9xl">
             {introContent.titleTop}
             <br />
-            <span className="bg-gradient-to-r from-[var(--brand-500)] to-[var(--brand-400)] bg-clip-text text-transparent">
+            <span className="text-[#FF4D00]">
               {introContent.titleAccent}
             </span>
           </h1>

--- a/src/components/sections/RoadmapSection.tsx
+++ b/src/components/sections/RoadmapSection.tsx
@@ -20,9 +20,9 @@ export function RoadmapSection() {
             <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
               {roadmapContent.label}
             </span>
-            <h2 className="text-3xl text-foreground dark:text-white md:text-5xl">
+            <h2 className="text-3xl font-bold text-foreground dark:text-white md:text-5xl">
               {roadmapContent.titleTop}{" "}
-              <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+              <span className="text-[#FF4D00]">
                 {roadmapContent.titleAccent}
               </span>
             </h2>

--- a/src/components/sections/RoadmapSection.tsx
+++ b/src/components/sections/RoadmapSection.tsx
@@ -13,7 +13,7 @@ const PHASE_ICONS: Record<string, LucideIcon> = {
 
 export function RoadmapSection() {
   return (
-    <section id="roadmap" className="relative scroll-mt-16 px-5 py-24 md:py-32">
+    <section id="roadmap" className="relative px-5 py-24 md:py-32">
       <div className="mx-auto max-w-4xl">
         <Reveal>
           <div className="relative z-10 mb-16 text-center">

--- a/src/components/sections/TeamSection.tsx
+++ b/src/components/sections/TeamSection.tsx
@@ -21,7 +21,7 @@ function MemberCard({ name, role, desc }: { name: string; role?: string; desc: s
 
 export function TeamSection() {
   return (
-    <section id="team" className="min-h-screen scroll-mt-16 bg-background px-5 py-24 md:py-32">
+    <section id="team" className="min-h-screen bg-background px-5 py-24 md:py-32">
       <div className="mx-auto max-w-6xl">
         <Reveal>
           <div className="mb-16 text-center">

--- a/src/components/sections/TeamSection.tsx
+++ b/src/components/sections/TeamSection.tsx
@@ -28,9 +28,9 @@ export function TeamSection() {
             <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
               {teamContent.label}
             </span>
-            <h2 className="mb-4 text-3xl text-foreground dark:text-white md:text-5xl">
+            <h2 className="mb-4 text-3xl font-bold text-foreground dark:text-white md:text-5xl">
               {teamContent.titleTop}{" "}
-              <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+              <span className="text-[#FF4D00]">
                 {teamContent.titleAccent}
               </span>
             </h2>

--- a/src/components/sections/VisionSection.tsx
+++ b/src/components/sections/VisionSection.tsx
@@ -13,7 +13,7 @@ const PILLAR_ICONS: Record<string, LucideIcon> = {
 
 export function VisionSection() {
   return (
-    <section id="vision" className="min-h-screen scroll-mt-16 bg-background dark:bg-[#0A0A0A] px-5 py-24 md:py-32">
+    <section id="vision" className="min-h-screen bg-background dark:bg-[#0A0A0A] px-5 py-24 md:py-32">
       <div className="mx-auto max-w-5xl">
         <Reveal>
           <div className="mb-16 text-center md:mb-20">

--- a/src/components/sections/VisionSection.tsx
+++ b/src/components/sections/VisionSection.tsx
@@ -20,10 +20,10 @@ export function VisionSection() {
             <span className="mb-4 block text-xs tracking-[0.3em] text-[#FF4D00] uppercase">
               {visionContent.label}
             </span>
-            <h2 className="text-3xl text-foreground dark:text-white md:text-5xl">
+            <h2 className="text-3xl font-bold text-foreground dark:text-white md:text-5xl">
               {visionContent.titleTop}
               <br />
-              <span className="bg-gradient-to-r from-[#FF4D00] to-[#FF8C00] bg-clip-text text-transparent">
+              <span className="text-[#FF4D00]">
                 {visionContent.titleAccent}
               </span>
             </h2>

--- a/src/components/site/DotNav.tsx
+++ b/src/components/site/DotNav.tsx
@@ -1,17 +1,23 @@
 import { navigationItems } from "@/content/landing";
 import { cn } from "@/lib/utils";
 
+const ACTIVE_NAV_ID_MAP: Record<string, string> = {
+  "cup-to-lion": "curriculum",
+};
+
 type DotNavProps = {
   activeId: string;
   onNavigate: (id: string) => void;
 };
 
 export function DotNav({ activeId, onNavigate }: DotNavProps) {
+  const activeNavId = ACTIVE_NAV_ID_MAP[activeId] || activeId;
+
   return (
     <nav className="fixed right-6 top-1/2 z-40 hidden -translate-y-1/2 lg:block">
       <ul className="flex flex-col gap-3">
         {navigationItems.map((item) => {
-          const isActive = item.id === activeId;
+          const isActive = item.id === activeNavId;
           return (
             <li key={item.id} className="flex h-4 w-4 items-center justify-center">
               <a

--- a/src/components/site/DotNav.tsx
+++ b/src/components/site/DotNav.tsx
@@ -1,25 +1,19 @@
 import { navigationItems } from "@/content/landing";
 import { cn } from "@/lib/utils";
 
-const ACTIVE_NAV_ID_MAP: Record<string, string> = {
-  "cup-to-lion": "curriculum",
-};
-
 type DotNavProps = {
   activeId: string;
   onNavigate: (id: string) => void;
 };
 
 export function DotNav({ activeId, onNavigate }: DotNavProps) {
-  const activeNavId = ACTIVE_NAV_ID_MAP[activeId] || activeId;
-
   return (
     <nav className="fixed right-6 top-1/2 z-40 hidden -translate-y-1/2 lg:block">
-      <ul className="flex flex-col gap-3">
+      <ul className="flex flex-col items-end gap-3">
         {navigationItems.map((item) => {
-          const isActive = item.id === activeNavId;
+          const isActive = item.id === activeId;
           return (
-            <li key={item.id} className="flex h-4 w-4 items-center justify-center">
+            <li key={item.id} className="flex h-5 items-center">
               <a
                 href={`#${item.id}`}
                 aria-current={isActive ? "true" : undefined}
@@ -27,17 +21,25 @@ export function DotNav({ activeId, onNavigate }: DotNavProps) {
                   event.preventDefault();
                   onNavigate(item.id);
                 }}
-                className={cn(
-                  "group flex h-4 w-4 items-center justify-center rounded-full outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-                )}
+                className="group relative flex items-center justify-end outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
               >
+                <span
+                  className={cn(
+                    "absolute right-full mr-3 whitespace-nowrap text-sm font-medium transition-all duration-300",
+                    isActive
+                      ? "translate-x-0 opacity-100 text-foreground"
+                      : "pointer-events-none translate-x-2 opacity-0 text-muted-foreground group-hover:translate-x-0 group-hover:opacity-100 group-hover:text-foreground/70"
+                  )}
+                >
+                  {item.label}
+                </span>
                 <span
                   aria-hidden="true"
                   className={cn(
-                    "h-2 w-2 rounded-full bg-muted-foreground transition-all duration-200",
+                    "h-2 rounded-full transition-all duration-300",
                     isActive
-                      ? "bg-primary scale-200"
-                      : "scale-100 group-hover:bg-foreground/70",
+                      ? "w-8 bg-primary"
+                      : "w-2 bg-muted-foreground group-hover:w-4 group-hover:bg-foreground/70"
                   )}
                 />
                 <span className="sr-only">{item.label}</span>

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -5,6 +5,10 @@ import { cn } from "@/lib/utils";
 
 import { ThemeToggle } from "./ThemeToggle";
 
+const ACTIVE_NAV_ID_MAP: Record<string, string> = {
+  "cup-to-lion": "curriculum",
+};
+
 const FOCUSABLE_SELECTOR =
   "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])";
 
@@ -108,6 +112,8 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
     [onNavigate],
   );
 
+  const activeNavId = ACTIVE_NAV_ID_MAP[activeId] || activeId;
+
   return (
     <header
       data-testid="site-header"
@@ -132,7 +138,7 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
 
         <nav className="hidden items-center gap-6 md:flex" aria-label="Primary">
           {navigationItems.map((item) => {
-            const isActive = item.id === activeId;
+            const isActive = item.id === activeNavId;
             return (
               <a
                 key={item.id}
@@ -182,7 +188,7 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
       >
         <nav className="flex flex-col gap-2" aria-label="Mobile primary">
           {navigationItems.map((item) => {
-            const isActive = item.id === activeId;
+            const isActive = item.id === activeNavId;
             return (
               <a
                 key={item.id}

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -5,10 +5,6 @@ import { cn } from "@/lib/utils";
 
 import { ThemeToggle } from "./ThemeToggle";
 
-const ACTIVE_NAV_ID_MAP: Record<string, string> = {
-  "cup-to-lion": "curriculum",
-};
-
 const FOCUSABLE_SELECTOR =
   "a[href], button:not([disabled]), [tabindex]:not([tabindex='-1'])";
 
@@ -112,8 +108,6 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
     [onNavigate],
   );
 
-  const activeNavId = ACTIVE_NAV_ID_MAP[activeId] || activeId;
-
   return (
     <header
       data-testid="site-header"
@@ -138,7 +132,7 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
 
         <nav className="hidden items-center gap-6 md:flex" aria-label="Primary">
           {navigationItems.map((item) => {
-            const isActive = item.id === activeNavId;
+            const isActive = item.id === activeId;
             return (
               <a
                 key={item.id}
@@ -188,7 +182,7 @@ export function SiteHeader({ activeId, onNavigate }: SiteHeaderProps) {
       >
         <nav className="flex flex-col gap-2" aria-label="Mobile primary">
           {navigationItems.map((item) => {
-            const isActive = item.id === activeNavId;
+            const isActive = item.id === activeId;
             return (
               <a
                 key={item.id}

--- a/src/content/landing.ts
+++ b/src/content/landing.ts
@@ -129,6 +129,7 @@ export const navigationItems: NavigationItem[] = [
   { id: "about", label: "About" },
   { id: "team", label: "Team" },
   { id: "curriculum", label: "Class" },
+  { id: "cup-to-lion", label: "Cup to Lion" },
   { id: "roadmap", label: "Schedule" },
   { id: "apply", label: "Apply" },
 ];

--- a/src/content/landing.ts
+++ b/src/content/landing.ts
@@ -106,6 +106,7 @@ type CupToLionContent = {
     title: string;
     desc: string;
     color: string;
+    icon: "search" | "shuffle" | "package";
   }>;
 };
 
@@ -336,18 +337,21 @@ export const cupToLionContent: CupToLionContent = {
       title: "실제 앱 분석 및 연구",
       desc: "시중에 나와있는 앱들을 다양한 관점으로 분석하고 공유합니다.",
       color: "#4ADE80",
+      icon: "search",
     },
     {
       step: "Step 2",
       title: "랜덤 아이디어 구조화",
       desc: "랜덤으로 주어진 주제에 맞게 아이디어를 구조화합니다.",
       color: "#60A5FA",
+      icon: "shuffle",
     },
     {
       step: "Step 3",
       title: "미니 Product 구현",
       desc: "Step 1, Step 2를 기반으로 미니 Product를 구현합니다.",
       color: "#FF8C00",
+      icon: "package",
     },
   ],
 };

--- a/src/content/landing.ts
+++ b/src/content/landing.ts
@@ -4,6 +4,7 @@ export type SectionId =
   | "about"
   | "team"
   | "curriculum"
+  | "cup-to-lion"
   | "roadmap"
   | "apply";
 
@@ -94,6 +95,20 @@ type RoadmapContent = {
   }>;
 };
 
+type CupToLionContent = {
+  label: string;
+  titleTop: string;
+  titleAccent: string;
+  descriptionTop: string;
+  descriptionBottom: string;
+  steps: Array<{
+    step: string;
+    title: string;
+    desc: string;
+    color: string;
+  }>;
+};
+
 type ApplyContent = {
   recruitLabel: string;
   titleTop: string;
@@ -118,7 +133,16 @@ export const navigationItems: NavigationItem[] = [
   { id: "apply", label: "Apply" },
 ];
 
-export const sectionOrder: SectionId[] = navigationItems.map((item) => item.id);
+export const sectionOrder: SectionId[] = [
+  "intro",
+  "vision",
+  "about",
+  "team",
+  "curriculum",
+  "cup-to-lion",
+  "roadmap",
+  "apply",
+];
 
 export const introContent: IntroContent = {
   badge: "LIKELION 14TH GENERATION @ CJU",
@@ -294,6 +318,35 @@ export const roadmapContent: RoadmapContent = {
       title: "Expansion",
       color: "#A78BFA",
       items: ["연합 해커톤 (충청권)", "기업 연계 프로젝트", "최종 성과 공유회 (Demoday)"],
+    },
+  ],
+};
+
+export const cupToLionContent: CupToLionContent = {
+  label: "Original Curriculum",
+  titleTop: "CUP TO",
+  titleAccent: "LION",
+  descriptionTop: "총 3가지의 Step으로 이루어진 청주대학교 멋쟁이사자처럼만의 자체 커리큘럼입니다.",
+  descriptionBottom:
+    "분석부터 아이디어 구조화, 미니 프로덕트 구현까지 단계적으로 경험하며 해커톤을 준비하는 청주대학교 멋쟁이사자처럼만의 성장 커리큘럼입니다.",
+  steps: [
+    {
+      step: "Step 1",
+      title: "실제 앱 분석 및 연구",
+      desc: "시중에 나와있는 앱들을 다양한 관점으로 분석하고 공유합니다.",
+      color: "#4ADE80",
+    },
+    {
+      step: "Step 2",
+      title: "랜덤 아이디어 구조화",
+      desc: "랜덤으로 주어진 주제에 맞게 아이디어를 구조화합니다.",
+      color: "#60A5FA",
+    },
+    {
+      step: "Step 3",
+      title: "미니 Product 구현",
+      desc: "Step 1, Step 2를 기반으로 미니 Product를 구현합니다.",
+      color: "#FF8C00",
     },
   ],
 };

--- a/src/index.css
+++ b/src/index.css
@@ -128,8 +128,8 @@ html.dark {
 }
 
 html {
-  scroll-behavior: smooth;
   scroll-padding-top: 64px;
+  scroll-behavior: smooth;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 
 import { AboutSection } from "@/components/sections/AboutSection";
 import { ApplySection } from "@/components/sections/ApplySection";
+import { CupToLionSection } from "@/components/sections/CupToLionSection";
 import { CurriculumSection } from "@/components/sections/CurriculumSection";
 import { IntroSection } from "@/components/sections/IntroSection";
 import { RoadmapSection } from "@/components/sections/RoadmapSection";
@@ -54,6 +55,7 @@ export function LandingPage() {
         <AboutSection />
         <TeamSection />
         <CurriculumSection />
+        <CupToLionSection />
         <RoadmapSection />
         <ApplySection />
       </main>


### PR DESCRIPTION
## 작업 내용
- 레퍼런스 사이트에 있는 누락 섹션 `cup-to-lion`을 별도 섹션 컴포넌트로 추가했습니다.
- 랜딩 콘텐츠 모델에 `cup-to-lion` 섹션 id/순서/데이터를 확장했습니다.
- 섹션 배치를 `curriculum`과 `roadmap` 사이로 삽입했습니다.
- `cup-to-lion` 구간에서도 네비게이션의 `Class` 활성 표시가 유지되도록 헤더/닷네비 매핑을 보완했습니다.
- E2E 섹션 존재 검증에 `#cup-to-lion`을 추가했습니다.

## 작업 이유
- Stage 5 릴리즈 전에 레퍼런스 대비 누락된 핵심 섹션을 반영해 구조 일치도를 맞추기 위함입니다.

## 검증 방법
- bun run lint
- bun run build
- bun run test:e2e